### PR TITLE
feat: add EventBasedPredictionMarket

### DIFF
--- a/contracts/EventBasedPredictionMarket.sol
+++ b/contracts/EventBasedPredictionMarket.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import "@uma/core/contracts/common/implementation/Testable.sol";
+
+import "@uma/core/contracts/oracle/interfaces/FinderInterface.sol";
+import "@uma/core/contracts/oracle/interfaces/OptimisticOracleInterface.sol";
+import "@uma/core/contracts/common/interfaces/ExpandedIERC20.sol";
+import "@uma/core/contracts/oracle/implementation/Constants.sol";
+import "@uma/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LongShortPairFinancialProductLibrary.sol";
+
+interface EventBasedPredictionMarketInterface {
+    // Create a pair of long/short tokens equal in number to tokensToCreate
+    function create(uint256 tokensToCreate) external returns (uint256 collateralUsed);
+
+    // Redeems a pair of long and short tokens equal in number to tokensToRedeem.
+    // Reverts if oracle hasPrice is true.
+    function redeem(uint256 tokensToRedeem) external returns (uint256 collateralReturned);
+
+    // Settle long and/or short tokens in for collateral at a rate informed by the contract settlement.
+    function settle(uint256 longTokensToRedeem, uint256 shortTokensToRedeem)
+        external
+        returns (uint256 collateralReturned);
+}
+
+abstract contract EventBasedPredictionMarket is EventBasedPredictionMarketInterface, Testable {
+    using SafeERC20 for IERC20;
+
+    bool public receivedSettlementPrice;
+
+    bool public enableEarlyExpiration; // If set, the LSP contract can request to be settled early by calling the OO.
+    uint256 public expirationTimestamp;
+    string public pairName;
+    uint256 public collateralPerPair; // Amount of collateral a pair of tokens is always redeemable for.
+
+    // Number between 0 and 1e18 to allocate collateral between long & short tokens at redemption. 0 entitles each short
+    // to collateralPerPair and each long to 0. 1e18 makes each long worth collateralPerPair and short 0.
+
+    // Number between 0 and 1e18 to allocate collateral between long & short tokens at redemption. 0 entitles each short
+    // to collateralPerPair and each long to 0. 1e18 makes each long worth collateralPerPair and short 0.
+    uint256 public expiryPercentLong;
+    bytes32 public priceIdentifier;
+
+    // Price returned from the Optimistic oracle at settlement time.
+    int256 public expiryPrice;
+
+    // External contract interfaces.
+    IERC20 public collateralToken;
+    ExpandedIERC20 public longToken;
+    ExpandedIERC20 public shortToken;
+    FinderInterface public finder;
+    LongShortPairFinancialProductLibrary public financialProductLibrary;
+
+    // Optimistic oracle customization parameters.
+    bytes public customAncillaryData;
+    uint256 public proposerReward;
+    uint256 public optimisticOracleLivenessTime;
+    uint256 public optimisticOracleProposerBond;
+
+    // Define the contract's constructor parameters as a struct to enable more variables to be specified.
+    struct ConstructorParams {
+        string pairName; // Name of the long short pair contract.
+        uint256 expirationTimestamp; // Unix timestamp of when the contract will expire.
+        uint256 collateralPerPair; // How many units of collateral are required to mint one pair of synthetic tokens.
+        bytes32 priceIdentifier; // Price identifier, registered in the DVM for the long short pair.
+        // bool enableEarlyExpiration; // Enables the LSP contract to be settled early.
+        ExpandedIERC20 longToken; // Token used as long in the LSP. Mint and burn rights needed by this contract.
+        ExpandedIERC20 shortToken; // Token used as short in the LSP. Mint and burn rights needed by this contract.
+        IERC20 collateralToken; // Collateral token used to back LSP synthetics.
+        LongShortPairFinancialProductLibrary financialProductLibrary; // Contract providing settlement payout logic.
+        bytes customAncillaryData; // Custom ancillary data to be passed along with the price request to the OO.
+        uint256 proposerReward; // Optimistic oracle reward amount, pulled from the caller of the expire function.
+        uint256 optimisticOracleLivenessTime; // OO liveness time for price requests.
+        uint256 optimisticOracleProposerBond; // OO proposer bond for price requests.
+        FinderInterface finder; // DVM finder to find other UMA ecosystem contracts.
+        address timerAddress; // Timer used to synchronize contract time in testing. Set to 0x000... in production.
+    }
+
+    constructor(ConstructorParams memory params) Testable(params.timerAddress) {
+        // During contract construction, set the contract's parameters.
+        // If the proposer reward was set then pull it from the caller of the function.
+        // requestPrice to OO
+        // setEventMarket
+        // Set the Optimistic oracle liveness for the price request.
+        // Set the Optimistic oracle proposer bond for the price request.
+
+        expirationTimestamp = getCurrentTime(); // Set the request timestamp to the current block timestamp.
+        _requestOraclePrice(expirationTimestamp, params.customAncillaryData); // Request the price from the OO.
+    }
+
+    // Request a price in the optimistic oracle for a given request timestamp and ancillary data combo. Set the bonds
+    // accordingly to the deployer's parameters. Will revert if re-requesting for a previously requested combo.
+    function _requestOraclePrice(uint256 _requestTimestamp, bytes memory requestAncillaryData) internal {
+        OptimisticOracleInterface optimisticOracle = _getOptimisticOracle();
+
+        // If the proposer reward was set then pull it from the caller of the function.
+        if (proposerReward > 0) {
+            collateralToken.safeTransferFrom(msg.sender, address(this), proposerReward);
+            collateralToken.safeApprove(address(optimisticOracle), proposerReward);
+        }
+        optimisticOracle.requestPrice(
+            priceIdentifier,
+            expirationTimestamp,
+            requestAncillaryData,
+            collateralToken,
+            proposerReward
+        );
+
+        // Set the Optimistic oracle liveness for the price request.
+        optimisticOracle.setCustomLiveness(
+            priceIdentifier,
+            expirationTimestamp,
+            requestAncillaryData,
+            optimisticOracleLivenessTime
+        );
+
+        // Set the Optimistic oracle proposer bond for the price request.
+        optimisticOracle.setBond(
+            priceIdentifier,
+            expirationTimestamp,
+            requestAncillaryData,
+            optimisticOracleProposerBond
+        );
+
+        // Make the request an event-based request.
+        optimisticOracle.setEventBased(priceIdentifier, expirationTimestamp, requestAncillaryData);
+    }
+
+    function _getOptimisticOracle() internal view returns (OptimisticOracleInterface) {
+        return OptimisticOracleInterface(finder.getImplementationAddress(OracleInterfaces.OptimisticOracle));
+    }
+}

--- a/contracts/EventBasedPredictionMarket.sol
+++ b/contracts/EventBasedPredictionMarket.sol
@@ -66,7 +66,9 @@ contract EventBasedPredictionMarket is Testable {
      ****************************************/
 
     modifier hasPrice() {
-        require(_getOO().hasPrice(address(this), priceIdentifier, expirationTimestamp, customAncillaryData));
+        require(
+            getOptimisticOracle().hasPrice(address(this), priceIdentifier, expirationTimestamp, customAncillaryData)
+        );
         _;
     }
 
@@ -140,7 +142,7 @@ contract EventBasedPredictionMarket is Testable {
         bytes memory ancillaryData,
         uint256 refund
     ) external {
-        OptimisticOracleInterface optimisticOracle = _getOO();
+        OptimisticOracleInterface optimisticOracle = getOptimisticOracle();
         require(msg.sender == address(optimisticOracle), "not authorized");
 
         expirationTimestamp = getCurrentTime();
@@ -232,7 +234,7 @@ contract EventBasedPredictionMarket is Testable {
      * accordingly to the deployer's parameters. Will revert if re-requesting for a previously requested combo.
      */
     function _requestOraclePrice() internal {
-        OptimisticOracleInterface optimisticOracle = _getOO();
+        OptimisticOracleInterface optimisticOracle = getOptimisticOracle();
 
         collateralToken.safeApprove(address(optimisticOracle), proposerReward);
 
@@ -300,7 +302,7 @@ contract EventBasedPredictionMarket is Testable {
      * @notice Get the optimistic oracle.
      * @return optimistic oracle instance.
      */
-    function _getOO() internal view returns (OptimisticOracleInterface) {
+    function getOptimisticOracle() internal view returns (OptimisticOracleInterface) {
         return OptimisticOracleInterface(finder.getImplementationAddress(OracleInterfaces.OptimisticOracle));
     }
 
@@ -311,6 +313,6 @@ contract EventBasedPredictionMarket is Testable {
      * @return oraclePrice price for the request.
      */
     function getOraclePrice(uint256 requestTimestamp, bytes memory requestAncillaryData) internal returns (int256) {
-        return _getOO().settleAndGetPrice(priceIdentifier, requestTimestamp, requestAncillaryData);
+        return getOptimisticOracle().settleAndGetPrice(priceIdentifier, requestTimestamp, requestAncillaryData);
     }
 }

--- a/contracts/EventBasedPredictionMarket.sol
+++ b/contracts/EventBasedPredictionMarket.sol
@@ -30,7 +30,7 @@ contract EventBasedPredictionMarket is Testable {
 
     uint256 public expirationTimestamp;
     string public pairName;
-    uint256 public collateralPerPair = 1 ether; // Amount of collateral a pair of tokens is always redeemable for.
+    uint256 public collateralPerPair = 1e18; // Amount of collateral a pair of tokens is always redeemable for.
 
     // Number between 0 and 1e18 to allocate collateral between long & short tokens at redemption. 0 entitles each short
     // to collateralPerPair and each long to 0. 1e18 makes each long worth collateralPerPair and short 0.
@@ -39,7 +39,7 @@ contract EventBasedPredictionMarket is Testable {
 
     // Price returned from the Optimistic oracle at settlement time.
     int256 public expiryPrice;
-    int256 public strikePrice = int256(1 ether);
+    int256 public strikePrice = int256(1e18);
 
     // External contract interfaces.
     ExpandedERC20 public collateralToken;
@@ -168,9 +168,9 @@ contract EventBasedPredictionMarket is Testable {
         // Note the use of multiply and ceiling to prevent small collateralPerPair causing rounding of collateralUsed to 0 enabling
         // callers to mint dust LSP tokens without paying any collateral.
         uint256 mulRaw = tokensToCreate * collateralPerPair;
-        uint256 mulFloor = mulRaw / 1 ether;
-        uint256 mod = mulRaw % 1 ether;
-        collateralUsed = mod != 0 ? mulFloor + 1 : mulFloor; // ceil(mulRaw / 1 ether)
+        uint256 mulFloor = mulRaw / 1e18;
+        uint256 mod = mulRaw % 1e18;
+        collateralUsed = mod != 0 ? mulFloor + 1 : mulFloor; // ceil(mulRaw / 1e18)
 
         collateralToken.safeTransferFrom(msg.sender, address(this), collateralUsed);
 
@@ -190,7 +190,7 @@ contract EventBasedPredictionMarket is Testable {
         require(longToken.burnFrom(msg.sender, tokensToRedeem));
         require(shortToken.burnFrom(msg.sender, tokensToRedeem));
 
-        collateralReturned = (tokensToRedeem * collateralPerPair) / 1 ether;
+        collateralReturned = (tokensToRedeem * collateralPerPair) / 1e18;
 
         collateralToken.safeTransfer(msg.sender, collateralReturned);
 
@@ -215,9 +215,9 @@ contract EventBasedPredictionMarket is Testable {
 
         // expiryPercentLong is a number between 0 and 1e18. 0 means all collateral goes to short tokens and 1e18 means
         // all collateral goes to the long token. Total collateral returned is the sum of payouts.
-        uint256 longCollateralRedeemed = (longTokensToRedeem * collateralPerPair * expiryPercentLong) / (1 ether**2);
-        uint256 shortCollateralRedeemed = (shortTokensToRedeem * collateralPerPair * (1 ether - expiryPercentLong)) /
-            (1 ether**2);
+        uint256 longCollateralRedeemed = (longTokensToRedeem * collateralPerPair * expiryPercentLong) / (1e18**2);
+        uint256 shortCollateralRedeemed = (shortTokensToRedeem * collateralPerPair * (1e18 - expiryPercentLong)) /
+            (1e18**2);
 
         collateralReturned = longCollateralRedeemed + shortCollateralRedeemed;
         collateralToken.safeTransfer(msg.sender, collateralReturned);
@@ -279,7 +279,7 @@ contract EventBasedPredictionMarket is Testable {
      * @return expiryPercentLong to indicate how much collateral should be sent between long and short tokens.
      */
     function percentageLongCollAtExpiry(int256 _expiryPrice) internal view returns (uint256) {
-        if (_expiryPrice >= strikePrice) return 1 ether;
+        if (_expiryPrice >= strikePrice) return 1e18;
         else return 0;
     }
 
@@ -293,7 +293,7 @@ contract EventBasedPredictionMarket is Testable {
         // Finally, compute the value of expiryPercentLong based on the expiryPrice. Cap the return value at 1e18 as
         // this should, by definition, between 0 and 1e18.
         expiryPercentLong = percentageLongCollAtExpiry(expiryPrice);
-        expiryPercentLong = expiryPercentLong < 1 ether ? expiryPercentLong : 1 ether;
+        expiryPercentLong = expiryPercentLong < 1e18 ? expiryPercentLong : 1e18;
 
         receivedSettlementPrice = true;
     }

--- a/contracts/EventBasedPredictionMarket.sol
+++ b/contracts/EventBasedPredictionMarket.sol
@@ -290,7 +290,7 @@ contract EventBasedPredictionMarket is Testable {
      * and customData combo then store this. If there is no price revert.
      */
     function getExpirationPrice() internal hasPrice {
-        expiryPrice = _getOP(expirationTimestamp, customAncillaryData);
+        expiryPrice = getOraclePrice(expirationTimestamp, customAncillaryData);
 
         // Finally, compute the value of expiryPercentLong based on the expiryPrice. Cap the return value at 1e18 as
         // this should, by definition, between 0 and 1e18.
@@ -314,7 +314,7 @@ contract EventBasedPredictionMarket is Testable {
      * @param requestAncillaryData ancillary data of the request.
      * @return oraclePrice price for the request.
      */
-    function _getOP(uint256 requestTimestamp, bytes memory requestAncillaryData) internal returns (int256) {
+    function getOraclePrice(uint256 requestTimestamp, bytes memory requestAncillaryData) internal returns (int256) {
         return _getOO().settleAndGetPrice(priceIdentifier, requestTimestamp, requestAncillaryData);
     }
 }

--- a/contracts/EventBasedPredictionMarket.sol
+++ b/contracts/EventBasedPredictionMarket.sol
@@ -1,10 +1,16 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
 
+import "hardhat/console.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
+
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import "@uma/core/contracts/common/implementation/Testable.sol";
+import "@uma/core/contracts/common/implementation/Lockable.sol";
+import "@uma/core/contracts/common/implementation/ExpandedERC20.sol";
+import "@uma/core/contracts/common/implementation/FixedPoint.sol";
 
 import "@uma/core/contracts/oracle/interfaces/FinderInterface.sol";
 import "@uma/core/contracts/oracle/interfaces/OptimisticOracleInterface.sol";
@@ -12,32 +18,28 @@ import "@uma/core/contracts/common/interfaces/ExpandedIERC20.sol";
 import "@uma/core/contracts/oracle/implementation/Constants.sol";
 import "@uma/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LongShortPairFinancialProductLibrary.sol";
 
-interface EventBasedPredictionMarketInterface {
-    // Create a pair of long/short tokens equal in number to tokensToCreate
-    function create(uint256 tokensToCreate) external returns (uint256 collateralUsed);
-
-    // Redeems a pair of long and short tokens equal in number to tokensToRedeem.
-    // Reverts if oracle hasPrice is true.
-    function redeem(uint256 tokensToRedeem) external returns (uint256 collateralReturned);
-
-    // Settle long and/or short tokens in for collateral at a rate informed by the contract settlement.
-    function settle(uint256 longTokensToRedeem, uint256 shortTokensToRedeem)
-        external
-        returns (uint256 collateralReturned);
+// TODO use OptimisticOracleInterface from @uma/core once it's updated with setEventBased
+interface OptimisticOracleInterfaceEventBased {
+    function setEventBased(
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes memory ancillaryData
+    ) external;
 }
 
-abstract contract EventBasedPredictionMarket is EventBasedPredictionMarketInterface, Testable {
+contract EventBasedPredictionMarket is Testable, Lockable {
+    using FixedPoint for FixedPoint.Unsigned;
     using SafeERC20 for IERC20;
+
+    /*************************************
+     *  EVENT BASED PREDICTION MARKET DATA STRUCTURES  *
+     *************************************/
 
     bool public receivedSettlementPrice;
 
-    bool public enableEarlyExpiration; // If set, the LSP contract can request to be settled early by calling the OO.
     uint256 public expirationTimestamp;
     string public pairName;
-    uint256 public collateralPerPair; // Amount of collateral a pair of tokens is always redeemable for.
-
-    // Number between 0 and 1e18 to allocate collateral between long & short tokens at redemption. 0 entitles each short
-    // to collateralPerPair and each long to 0. 1e18 makes each long worth collateralPerPair and short 0.
+    uint256 public collateralPerPair = 1 ether; // Amount of collateral a pair of tokens is always redeemable for.
 
     // Number between 0 and 1e18 to allocate collateral between long & short tokens at redemption. 0 entitles each short
     // to collateralPerPair and each long to 0. 1e18 makes each long worth collateralPerPair and short 0.
@@ -56,44 +58,74 @@ abstract contract EventBasedPredictionMarket is EventBasedPredictionMarketInterf
 
     // Optimistic oracle customization parameters.
     bytes public customAncillaryData;
-    uint256 public proposerReward;
-    uint256 public optimisticOracleLivenessTime;
-    uint256 public optimisticOracleProposerBond;
+    uint256 public proposerReward = 10;
+    uint256 public optimisticOracleLivenessTime = 60;
+    uint256 public optimisticOracleProposerBond = 100;
+
+    /****************************************
+     *                EVENTS                *
+     ****************************************/
+
+    event TokensCreated(address indexed sponsor, uint256 indexed collateralUsed, uint256 indexed tokensMinted);
+    event TokensRedeemed(address indexed sponsor, uint256 indexed collateralReturned, uint256 indexed tokensRedeemed);
+    event PositionSettled(address indexed sponsor, uint256 collateralReturned, uint256 longTokens, uint256 shortTokens);
+
+    /****************************************
+     *               MODIFIERS              *
+     ****************************************/
+
+    modifier hasPrice() {
+        require(
+            _getOptimisticOracle().hasPrice(address(this), priceIdentifier, expirationTimestamp, customAncillaryData),
+            "Only callable if the optimistic oracle has a price for this identifier."
+        );
+        _;
+    }
+
+    modifier priceRequested() {
+        require(
+            _getOptimisticOracle().getState(address(this), priceIdentifier, expirationTimestamp, customAncillaryData) >
+                OptimisticOracleInterface.State.Invalid,
+            "Price not requested"
+        );
+        _;
+    }
 
     // Define the contract's constructor parameters as a struct to enable more variables to be specified.
     struct ConstructorParams {
-        string pairName; // Name of the long short pair contract.
-        uint256 expirationTimestamp; // Unix timestamp of when the contract will expire.
-        uint256 collateralPerPair; // How many units of collateral are required to mint one pair of synthetic tokens.
+        string pairName;
         bytes32 priceIdentifier; // Price identifier, registered in the DVM for the long short pair.
-        // bool enableEarlyExpiration; // Enables the LSP contract to be settled early.
-        ExpandedIERC20 longToken; // Token used as long in the LSP. Mint and burn rights needed by this contract.
-        ExpandedIERC20 shortToken; // Token used as short in the LSP. Mint and burn rights needed by this contract.
         IERC20 collateralToken; // Collateral token used to back LSP synthetics.
         LongShortPairFinancialProductLibrary financialProductLibrary; // Contract providing settlement payout logic.
         bytes customAncillaryData; // Custom ancillary data to be passed along with the price request to the OO.
-        uint256 proposerReward; // Optimistic oracle reward amount, pulled from the caller of the expire function.
-        uint256 optimisticOracleLivenessTime; // OO liveness time for price requests.
-        uint256 optimisticOracleProposerBond; // OO proposer bond for price requests.
         FinderInterface finder; // DVM finder to find other UMA ecosystem contracts.
         address timerAddress; // Timer used to synchronize contract time in testing. Set to 0x000... in production.
     }
 
     constructor(ConstructorParams memory params) Testable(params.timerAddress) {
-        // During contract construction, set the contract's parameters.
-        // If the proposer reward was set then pull it from the caller of the function.
-        // requestPrice to OO
-        // setEventMarket
-        // Set the Optimistic oracle liveness for the price request.
-        // Set the Optimistic oracle proposer bond for the price request.
-
         expirationTimestamp = getCurrentTime(); // Set the request timestamp to the current block timestamp.
-        _requestOraclePrice(expirationTimestamp, params.customAncillaryData); // Request the price from the OO.
+
+        longToken = new ExpandedERC20(string(abi.encodePacked(params.pairName, " Long Token")), "PLT", 18);
+        shortToken = new ExpandedERC20(string(abi.encodePacked(params.pairName, " Short Token")), "PST", 18);
+
+        finder = params.finder;
+
+        collateralToken = params.collateralToken;
+        financialProductLibrary = params.financialProductLibrary;
+        customAncillaryData = params.customAncillaryData;
+        priceIdentifier = params.priceIdentifier;
+        pairName = params.pairName;
+    }
+
+    // Requests the price from the optimistic oracle
+    // The caller must have sufficient balance to pay the proposer reward and approve the contract to spend the collateral.
+    function initializeMarket() public {
+        _requestOraclePrice(customAncillaryData);
     }
 
     // Request a price in the optimistic oracle for a given request timestamp and ancillary data combo. Set the bonds
     // accordingly to the deployer's parameters. Will revert if re-requesting for a previously requested combo.
-    function _requestOraclePrice(uint256 _requestTimestamp, bytes memory requestAncillaryData) internal {
+    function _requestOraclePrice(bytes memory requestAncillaryData) internal {
         OptimisticOracleInterface optimisticOracle = _getOptimisticOracle();
 
         // If the proposer reward was set then pull it from the caller of the function.
@@ -126,7 +158,126 @@ abstract contract EventBasedPredictionMarket is EventBasedPredictionMarketInterf
         );
 
         // Make the request an event-based request.
-        optimisticOracle.setEventBased(priceIdentifier, expirationTimestamp, requestAncillaryData);
+        OptimisticOracleInterfaceEventBased(address(optimisticOracle)).setEventBased(
+            priceIdentifier,
+            expirationTimestamp,
+            requestAncillaryData
+        );
+    }
+
+    /****************************************
+     *          POSITION FUNCTIONS          *
+     ****************************************/
+
+    /**
+     * @notice Creates a pair of long and short tokens equal in number to tokensToCreate. Pulls the required collateral
+     * amount into this contract, defined by the collateralPerPair value.
+     * @dev The caller must approve this contract to transfer `tokensToCreate * collateralPerPair` amount of collateral.
+     * @param tokensToCreate number of long and short synthetic tokens to create.
+     * @return collateralUsed total collateral used to mint the synthetics.
+     */
+    function create(uint256 tokensToCreate) public priceRequested nonReentrant returns (uint256 collateralUsed) {
+        // Note the use of mulCeil to prevent small collateralPerPair causing rounding of collateralUsed to 0 enabling
+        // callers to mint dust LSP tokens without paying any collateral.
+        collateralUsed = FixedPoint.Unsigned(tokensToCreate).mulCeil(FixedPoint.Unsigned(collateralPerPair)).rawValue;
+
+        collateralToken.safeTransferFrom(msg.sender, address(this), collateralUsed);
+
+        require(longToken.mint(msg.sender, tokensToCreate));
+        require(shortToken.mint(msg.sender, tokensToCreate));
+
+        emit TokensCreated(msg.sender, collateralUsed, tokensToCreate);
+    }
+
+    /**
+     * @notice Redeems a pair of long and short tokens equal in number to tokensToRedeem. Returns the commensurate
+     * amount of collateral to the caller for the pair of tokens, defined by the collateralPerPair value.
+     * @dev This contract must have the `Burner` role for the `longToken` and `shortToken` in order to call `burnFrom`.
+     * @dev The caller does not need to approve this contract to transfer any amount of `tokensToRedeem` since long
+     * and short tokens are burned, rather than transferred, from the caller.
+     * @dev This method can be called either pre or post expiration.
+     * @param tokensToRedeem number of long and short synthetic tokens to redeem.
+     * @return collateralReturned total collateral returned in exchange for the pair of synthetics.
+     */
+    function redeem(uint256 tokensToRedeem) public nonReentrant returns (uint256 collateralReturned) {
+        require(longToken.burnFrom(msg.sender, tokensToRedeem));
+        require(shortToken.burnFrom(msg.sender, tokensToRedeem));
+
+        collateralReturned = FixedPoint.Unsigned(tokensToRedeem).mul(FixedPoint.Unsigned(collateralPerPair)).rawValue;
+
+        collateralToken.safeTransfer(msg.sender, collateralReturned);
+
+        emit TokensRedeemed(msg.sender, collateralReturned, tokensToRedeem);
+    }
+
+    /**
+     * @notice Settle long and/or short tokens in for collateral at a rate informed by the contract settlement.
+     * @dev Uses financialProductLibrary to compute the redemption rate between long and short tokens.
+     * @dev This contract must have the `Burner` role for the `longToken` and `shortToken` in order to call `burnFrom`.
+     * @dev The caller does not need to approve this contract to transfer any amount of `tokensToRedeem` since long
+     * and short tokens are burned, rather than transferred, from the caller.
+     * @dev This function can be called before or after expiration to facilitate early expiration. If a price has
+     * not yet been resolved for either normal or early expiration yet then it will revert.
+     * @param longTokensToRedeem number of long tokens to settle.
+     * @param shortTokensToRedeem number of short tokens to settle.
+     * @return collateralReturned total collateral returned in exchange for the pair of synthetics.
+     */
+    function settle(uint256 longTokensToRedeem, uint256 shortTokensToRedeem)
+        public
+        nonReentrant
+        returns (uint256 collateralReturned)
+    {
+        // Get the settlement price and store it. Also sets expiryPercentLong to inform settlement. Reverts if either:
+        // a) the price request has not resolved (either a normal expiration call or early expiration call) or b) If the
+        // the contract was attempted to be settled early but the price returned is the ignore oracle price.
+        // Note that we use the bool receivedSettlementPrice over checking for price != 0 as 0 is a valid price.
+        if (!receivedSettlementPrice) getExpirationPrice();
+
+        require(longToken.burnFrom(msg.sender, longTokensToRedeem));
+        require(shortToken.burnFrom(msg.sender, shortTokensToRedeem));
+
+        // expiryPercentLong is a number between 0 and 1e18. 0 means all collateral goes to short tokens and 1e18 means
+        // all collateral goes to the long token. Total collateral returned is the sum of payouts.
+        uint256 longCollateralRedeemed = FixedPoint
+            .Unsigned(longTokensToRedeem)
+            .mul(FixedPoint.Unsigned(collateralPerPair))
+            .mul(FixedPoint.Unsigned(expiryPercentLong))
+            .rawValue;
+        uint256 shortCollateralRedeemed = FixedPoint
+            .Unsigned(shortTokensToRedeem)
+            .mul(FixedPoint.Unsigned(collateralPerPair))
+            .mul(FixedPoint.fromUnscaledUint(1).sub(FixedPoint.Unsigned(expiryPercentLong)))
+            .rawValue;
+
+        collateralReturned = longCollateralRedeemed + shortCollateralRedeemed;
+        collateralToken.safeTransfer(msg.sender, collateralReturned);
+
+        emit PositionSettled(msg.sender, collateralReturned, longTokensToRedeem, shortTokensToRedeem);
+    }
+
+    /****************************************
+     *          INTERNAL FUNCTIONS          *
+     ****************************************/
+
+    // Return the oracle price for a given request timestamp and ancillary data combo.
+    function _getOraclePrice(uint256 requestTimestamp, bytes memory requestAncillaryData) internal returns (int256) {
+        return _getOptimisticOracle().settleAndGetPrice(priceIdentifier, requestTimestamp, requestAncillaryData);
+    }
+
+    // Fetch the optimistic oracle expiration price. If the oracle has the price for the provided expiration timestamp
+    // and customData combo then return this. Else, try fetch the price on the early expiration ancillary data. If
+    // there is no price for either, revert. If the early expiration price is the ignore price will also revert.
+    function getExpirationPrice() internal hasPrice {
+        expiryPrice = _getOraclePrice(expirationTimestamp, customAncillaryData);
+
+        // Finally, compute the value of expiryPercentLong based on the expiryPrice. Cap the return value at 1e18 as
+        // this should, by definition, between 0 and 1e18.
+        expiryPercentLong = Math.min(
+            financialProductLibrary.percentageLongCollateralAtExpiry(expiryPrice),
+            FixedPoint.fromUnscaledUint(1).rawValue
+        );
+
+        receivedSettlementPrice = true;
     }
 
     function _getOptimisticOracle() internal view returns (OptimisticOracleInterface) {

--- a/contracts/EventBasedPredictionMarket.sol
+++ b/contracts/EventBasedPredictionMarket.sol
@@ -164,7 +164,6 @@ contract EventBasedPredictionMarket is Testable {
     /**
      * @notice Creates a pair of long and short tokens equal in number to tokensToCreate. Pulls the required collateral
      * amount into this contract, defined by the collateralPerPair value.
-     * @dev The caller must approve this contract to transfer `tokensToCreate * collateralPerPair` amount of collateral.
      * @param tokensToCreate number of long and short synthetic tokens to create.
      * @return collateralUsed total collateral used to mint the synthetics.
      */
@@ -184,10 +183,6 @@ contract EventBasedPredictionMarket is Testable {
     /**
      * @notice Redeems a pair of long and short tokens equal in number to tokensToRedeem. Returns the commensurate
      * amount of collateral to the caller for the pair of tokens, defined by the collateralPerPair value.
-     * @dev This contract must have the `Burner` role for the `longToken` and `shortToken` in order to call `burnFrom`.
-     * @dev The caller does not need to approve this contract to transfer any amount of `tokensToRedeem` since long
-     * and short tokens are burned, rather than transferred, from the caller.
-     * @dev This method can be called either pre or post expiration.
      * @param tokensToRedeem number of long and short synthetic tokens to redeem.
      * @return collateralReturned total collateral returned in exchange for the pair of synthetics.
      */
@@ -204,12 +199,6 @@ contract EventBasedPredictionMarket is Testable {
 
     /**
      * @notice Settle long and/or short tokens in for collateral at a rate informed by the contract settlement.
-     * @dev Uses financialProductLibrary to compute the redemption rate between long and short tokens.
-     * @dev This contract must have the `Burner` role for the `longToken` and `shortToken` in order to call `burnFrom`.
-     * @dev The caller does not need to approve this contract to transfer any amount of `tokensToRedeem` since long
-     * and short tokens are burned, rather than transferred, from the caller.
-     * @dev This function can be called before or after expiration to facilitate early expiration. If a price has
-     * not yet been resolved for either normal or early expiration yet then it will revert.
      * @param longTokensToRedeem number of long tokens to settle.
      * @param shortTokensToRedeem number of short tokens to settle.
      * @return collateralReturned total collateral returned in exchange for the pair of synthetics.
@@ -218,10 +207,7 @@ contract EventBasedPredictionMarket is Testable {
         public
         returns (uint256 collateralReturned)
     {
-        // Get the settlement price and store it. Also sets expiryPercentLong to inform settlement. Reverts if either:
-        // a) the price request has not resolved (either a normal expiration call or early expiration call) or b) If the
-        // the contract was attempted to be settled early but the price returned is the ignore oracle price.
-        // Note that we use the bool receivedSettlementPrice over checking for price != 0 as 0 is a valid price.
+        // Get the settlement price and store it. Reverts if price has not yet been resolved.
         if (!receivedSettlementPrice) getExpirationPrice();
 
         require(longToken.burnFrom(msg.sender, longTokensToRedeem));

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "dependencies": {
     "@openzeppelin/contracts": "^4.4.2",
-    "@uma/common": "^2.17.0",
-    "@uma/contracts-node": "^0.2.0"
+    "@uma/common": "^2.20.0",
+    "@uma/contracts-node": "^0.3.7"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint": "yarn prettier --list-different",
     "lint-fix": "yarn prettier --write",
     "prettier": "prettier .",
-    "test": "hardhat test"
+    "test": "hardhat test",
+    "compile": "hardhat compile"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^4.4.2",

--- a/test/EventBasedPredictionMarket.ts
+++ b/test/EventBasedPredictionMarket.ts
@@ -6,9 +6,7 @@ import { umaEcosystemFixture } from "./fixtures/UmaEcosystem.Fixture";
 import { BigNumber, Contract, ethers, expect, SignerWithAddress, toWei } from "./utils";
 
 let eventBasedPredictionMarket: EventBasedPredictionMarket, usdc: Contract;
-let optimisticOracle: OptimisticOracle;
-let longToken: ExpandedERC20;
-let shortToken: ExpandedERC20;
+let optimisticOracle: OptimisticOracle, longToken: ExpandedERC20, shortToken: ExpandedERC20;
 let deployer: SignerWithAddress, sponsor: SignerWithAddress, holder: SignerWithAddress, disputer: SignerWithAddress;
 
 describe("EventBasedPredictionMarket functions", function () {
@@ -86,11 +84,6 @@ describe("EventBasedPredictionMarket functions", function () {
 
     // The EventBasedPredictionMarket shouldn't have received the settlement price.
     expect(await eventBasedPredictionMarket.receivedSettlementPrice()).to.equal(false);
-
-    // It shouldn't be possible to create tokens after the price has been settled.
-    await expect(eventBasedPredictionMarket.connect(sponsor).create(toWei(100))).to.be.revertedWith(
-      "VM Exception while processing transaction: reverted with reason string 'Price already proposed.'"
-    );
 
     // Holder redeems his long tokens.
     await eventBasedPredictionMarket.connect(holder).settle(toWei("50"), 0);

--- a/test/EventBasedPredictionMarket.ts
+++ b/test/EventBasedPredictionMarket.ts
@@ -1,15 +1,15 @@
-import { SignerWithAddress, expect, Contract, ethers, toWei, BigNumber } from "../utils";
-import { umaEcosystemFixture } from "../fixtures/UmaEcosystem.Fixture";
-import { eventBasedPredictionMarketFixture } from "../fixtures/EventBasedPredictionMarket.Fixture";
-import { amountToSeedWallets, amountToDeposit } from "../constants";
 import { OptimisticOracle } from "@uma/contracts-node/dist/packages/contracts-node/typechain/core/ethers";
-import { EventBasedPredictionMarket, ExpandedERC20 } from "../../typechain";
+import { EventBasedPredictionMarket, ExpandedERC20 } from "../typechain";
+import { amountToSeedWallets } from "./constants";
+import { eventBasedPredictionMarketFixture } from "./fixtures/EventBasedPredictionMarket.Fixture";
+import { umaEcosystemFixture } from "./fixtures/UmaEcosystem.Fixture";
+import { BigNumber, Contract, ethers, expect, SignerWithAddress, toWei } from "./utils";
 
-let eventBasedPredictionMarket: EventBasedPredictionMarket, usdc: Contract, collateralWhitelist: Contract;
+let eventBasedPredictionMarket: EventBasedPredictionMarket, usdc: Contract;
 let optimisticOracle: OptimisticOracle;
 let longToken: ExpandedERC20;
 let shortToken: ExpandedERC20;
-let deployer: SignerWithAddress, sponsor: SignerWithAddress, holder: SignerWithAddress;
+let deployer: SignerWithAddress, sponsor: SignerWithAddress, holder: SignerWithAddress, disputer: SignerWithAddress;
 
 describe("EventBasedPredictionMarket functions", function () {
   const proposeAndSettleOptimisticOraclePrice = async (price: BigNumber) => {
@@ -32,14 +32,15 @@ describe("EventBasedPredictionMarket functions", function () {
   };
 
   beforeEach(async function () {
-    [deployer, sponsor, holder] = await ethers.getSigners();
+    [deployer, sponsor, holder, disputer] = await ethers.getSigners();
 
-    ({ collateralWhitelist, optimisticOracle } = await umaEcosystemFixture());
+    ({ optimisticOracle } = await umaEcosystemFixture());
     ({ eventBasedPredictionMarket, usdc, longToken, shortToken } = await eventBasedPredictionMarketFixture());
 
-    // mint some fresh tokens for the sponsor and deployer.
+    // mint some fresh tokens for the sponsor, deployer and disputer.
     await usdc.connect(deployer).mint(sponsor.address, amountToSeedWallets);
     await usdc.connect(deployer).mint(deployer.address, amountToSeedWallets);
+    await usdc.connect(deployer).mint(disputer.address, amountToSeedWallets);
 
     // Approve the EventBasedPredictionMarket to spend tokens
     await usdc.connect(sponsor).approve(eventBasedPredictionMarket.address, amountToSeedWallets);
@@ -47,11 +48,12 @@ describe("EventBasedPredictionMarket functions", function () {
 
     // Approve the Optimistic Oracle to spend bond tokens
     await usdc.connect(deployer).approve(optimisticOracle.address, amountToSeedWallets);
+    await usdc.connect(disputer).approve(optimisticOracle.address, amountToSeedWallets);
 
     await eventBasedPredictionMarket.connect(deployer).initializeMarket();
   });
 
-  it("Mint, redeem, expire lifecycle", async function () {
+  it("Event-based mint, redeem and expire lifecycle", async function () {
     // Create some sponsor tokens. Send half to the holder account.
     expect(await usdc.balanceOf(sponsor.address)).to.equal(amountToSeedWallets);
     expect(await longToken.balanceOf(sponsor.address)).to.equal(0);
@@ -69,9 +71,7 @@ describe("EventBasedPredictionMarket functions", function () {
     await eventBasedPredictionMarket.connect(sponsor).redeem(toWei("25"));
 
     // Sponsor should have 25 remaining long tokens and 75 remaining short tokens. They should have been refunded 25 collateral.
-    expect((await usdc.balanceOf(sponsor.address)).toString()).to.equal(
-      amountToSeedWallets.sub(toWei(100)).add(toWei(25))
-    ); // -100 after mint + 25 redeemed.
+    expect(await usdc.balanceOf(sponsor.address)).to.equal(amountToSeedWallets.sub(toWei(100)).add(toWei(25))); // -100 after mint + 25 redeemed.
     expect(await longToken.balanceOf(sponsor.address)).to.equal(toWei("25"));
     expect(await shortToken.balanceOf(sponsor.address)).to.equal(toWei("75"));
 
@@ -86,6 +86,11 @@ describe("EventBasedPredictionMarket functions", function () {
 
     // The EventBasedPredictionMarket shouldn't have received the settlement price.
     expect(await eventBasedPredictionMarket.receivedSettlementPrice()).to.equal(false);
+
+    // It shouldn't be possible to create tokens after the price has been settled.
+    await expect(eventBasedPredictionMarket.connect(sponsor).create(toWei(100))).to.be.revertedWith(
+      "VM Exception while processing transaction: reverted with reason string 'Price already proposed.'"
+    );
 
     // Holder redeems his long tokens.
     await eventBasedPredictionMarket.connect(holder).settle(toWei("50"), 0);
@@ -104,5 +109,40 @@ describe("EventBasedPredictionMarket functions", function () {
 
     // long short pair should have no collateral left in it as everything has been redeemed.
     expect(await usdc.balanceOf(eventBasedPredictionMarket.address)).to.equal(0);
+  });
+
+  it("Event-based dispute workflow with auto re-request on dispute.", async function () {
+    const requestSubmissionTimestamp = await eventBasedPredictionMarket.expirationTimestamp();
+    const proposalSubmissionTimestamp = parseInt(requestSubmissionTimestamp.toString()) + 100;
+    await optimisticOracle.connect(deployer).setCurrentTime(proposalSubmissionTimestamp);
+
+    const ancillaryData = await eventBasedPredictionMarket.customAncillaryData();
+    const identifier = await eventBasedPredictionMarket.priceIdentifier();
+    const expirationTimestamp = await eventBasedPredictionMarket.expirationTimestamp();
+
+    await optimisticOracle
+      .connect(deployer)
+      .proposePrice(eventBasedPredictionMarket.address, identifier, expirationTimestamp, ancillaryData, 0);
+
+    const disputeSubmissionTimestamp = proposalSubmissionTimestamp + 100;
+    await optimisticOracle.connect(deployer).setCurrentTime(disputeSubmissionTimestamp);
+    await optimisticOracle
+      .connect(disputer)
+      .disputePrice(eventBasedPredictionMarket.address, identifier, expirationTimestamp, ancillaryData);
+
+    // Check that the price has been re-requested with a new expiration timestamp corresponding to the dispute timestamp.
+    expect(await eventBasedPredictionMarket.expirationTimestamp()).to.equal(disputeSubmissionTimestamp);
+    expect(await usdc.balanceOf(eventBasedPredictionMarket.address)).to.equal(0);
+
+    // Sponsor creates some Long short tokens
+    await eventBasedPredictionMarket.connect(sponsor).create(toWei(100));
+
+    // Propose and settle a new undisputed price
+    await proposeAndSettleOptimisticOraclePrice(toWei(1));
+
+    // Check that the price has been settled and Long short tokens can be refunded.
+    const sponsorInitialBalance = await usdc.balanceOf(sponsor.address);
+    await eventBasedPredictionMarket.connect(sponsor).settle(toWei("100"), toWei("0"));
+    expect(await usdc.balanceOf(sponsor.address)).to.equal(sponsorInitialBalance.add(toWei(100)));
   });
 });

--- a/test/EventBasedPredictionMarket.ts
+++ b/test/EventBasedPredictionMarket.ts
@@ -16,17 +16,17 @@ describe("EventBasedPredictionMarket functions", function () {
     const expirationTimestamp = await eventBasedPredictionMarket.expirationTimestamp();
     const optimisticOracleLivenessTime = await eventBasedPredictionMarket.optimisticOracleLivenessTime();
 
-    await optimisticOracle
-      .connect(deployer)
-      .proposePrice(eventBasedPredictionMarket.address, identifier, expirationTimestamp, ancillaryData, price);
+    await optimisticOracle.proposePrice(
+      eventBasedPredictionMarket.address,
+      identifier,
+      expirationTimestamp,
+      ancillaryData,
+      price
+    );
 
-    await optimisticOracle
-      .connect(deployer)
-      .setCurrentTime((await optimisticOracle.getCurrentTime()).add(optimisticOracleLivenessTime));
+    await optimisticOracle.setCurrentTime((await optimisticOracle.getCurrentTime()).add(optimisticOracleLivenessTime));
 
-    await optimisticOracle
-      .connect(deployer)
-      .settle(eventBasedPredictionMarket.address, identifier, expirationTimestamp, ancillaryData);
+    await optimisticOracle.settle(eventBasedPredictionMarket.address, identifier, expirationTimestamp, ancillaryData);
   };
 
   beforeEach(async function () {
@@ -36,19 +36,19 @@ describe("EventBasedPredictionMarket functions", function () {
     ({ eventBasedPredictionMarket, usdc, longToken, shortToken } = await eventBasedPredictionMarketFixture());
 
     // mint some fresh tokens for the sponsor, deployer and disputer.
-    await usdc.connect(deployer).mint(sponsor.address, amountToSeedWallets);
-    await usdc.connect(deployer).mint(deployer.address, amountToSeedWallets);
-    await usdc.connect(deployer).mint(disputer.address, amountToSeedWallets);
+    await usdc.mint(sponsor.address, amountToSeedWallets);
+    await usdc.mint(deployer.address, amountToSeedWallets);
+    await usdc.mint(disputer.address, amountToSeedWallets);
 
     // Approve the EventBasedPredictionMarket to spend tokens
     await usdc.connect(sponsor).approve(eventBasedPredictionMarket.address, amountToSeedWallets);
-    await usdc.connect(deployer).approve(eventBasedPredictionMarket.address, amountToSeedWallets);
+    await usdc.approve(eventBasedPredictionMarket.address, amountToSeedWallets);
 
     // Approve the Optimistic Oracle to spend bond tokens
-    await usdc.connect(deployer).approve(optimisticOracle.address, amountToSeedWallets);
+    await usdc.approve(optimisticOracle.address, amountToSeedWallets);
     await usdc.connect(disputer).approve(optimisticOracle.address, amountToSeedWallets);
 
-    await eventBasedPredictionMarket.connect(deployer).initializeMarket();
+    await eventBasedPredictionMarket.initializeMarket();
   });
 
   it("Event-based mint, redeem and expire lifecycle.", async function () {
@@ -140,18 +140,22 @@ describe("EventBasedPredictionMarket functions", function () {
   it("Event-based dispute workflow with auto re-request on dispute.", async function () {
     const requestSubmissionTimestamp = await eventBasedPredictionMarket.expirationTimestamp();
     const proposalSubmissionTimestamp = parseInt(requestSubmissionTimestamp.toString()) + 100;
-    await optimisticOracle.connect(deployer).setCurrentTime(proposalSubmissionTimestamp);
+    await optimisticOracle.setCurrentTime(proposalSubmissionTimestamp);
 
     const ancillaryData = await eventBasedPredictionMarket.customAncillaryData();
     const identifier = await eventBasedPredictionMarket.priceIdentifier();
     const expirationTimestamp = await eventBasedPredictionMarket.expirationTimestamp();
 
-    await optimisticOracle
-      .connect(deployer)
-      .proposePrice(eventBasedPredictionMarket.address, identifier, expirationTimestamp, ancillaryData, 0);
+    await optimisticOracle.proposePrice(
+      eventBasedPredictionMarket.address,
+      identifier,
+      expirationTimestamp,
+      ancillaryData,
+      0
+    );
 
     const disputeSubmissionTimestamp = proposalSubmissionTimestamp + 100;
-    await optimisticOracle.connect(deployer).setCurrentTime(disputeSubmissionTimestamp);
+    await optimisticOracle.setCurrentTime(disputeSubmissionTimestamp);
     await optimisticOracle
       .connect(disputer)
       .disputePrice(eventBasedPredictionMarket.address, identifier, expirationTimestamp, ancillaryData);

--- a/test/EventBasedPredictionMarket.ts
+++ b/test/EventBasedPredictionMarket.ts
@@ -108,8 +108,7 @@ describe("EventBasedPredictionMarket functions", function () {
     await eventBasedPredictionMarket.connect(sponsor).create(toWei(100));
 
     const createEvents = await eventBasedPredictionMarket.queryFilter(
-      eventBasedPredictionMarket.filters.TokensCreated(),
-      "latest"
+      eventBasedPredictionMarket.filters.TokensCreated()
     );
     expect(createEvents[0].args.sponsor === sponsor.address);
 
@@ -120,8 +119,7 @@ describe("EventBasedPredictionMarket functions", function () {
     await eventBasedPredictionMarket.connect(sponsor).redeem(toWei("25"));
 
     const tokensRedeemedEvents = await eventBasedPredictionMarket.queryFilter(
-      eventBasedPredictionMarket.filters.TokensRedeemed(),
-      "latest"
+      eventBasedPredictionMarket.filters.TokensRedeemed()
     );
     expect(tokensRedeemedEvents[0].args.sponsor === sponsor.address);
 
@@ -131,8 +129,7 @@ describe("EventBasedPredictionMarket functions", function () {
     await eventBasedPredictionMarket.connect(holder).settle(toWei("50"), 0);
 
     const positionSettledEvents = await eventBasedPredictionMarket.queryFilter(
-      eventBasedPredictionMarket.filters.PositionSettled(),
-      "latest"
+      eventBasedPredictionMarket.filters.PositionSettled()
     );
     expect(positionSettledEvents[0].args.sponsor === holder.address);
   });

--- a/test/eventBasedPredictionMarket/EventBasedPredictionMarket.ts
+++ b/test/eventBasedPredictionMarket/EventBasedPredictionMarket.ts
@@ -1,25 +1,108 @@
-import { SignerWithAddress, expect, Contract, ethers } from "../utils";
+import { SignerWithAddress, expect, Contract, ethers, toWei, BigNumber } from "../utils";
 import { umaEcosystemFixture } from "../fixtures/UmaEcosystem.Fixture";
 import { eventBasedPredictionMarketFixture } from "../fixtures/EventBasedPredictionMarket.Fixture";
 import { amountToSeedWallets, amountToDeposit } from "../constants";
+import { OptimisticOracle } from "@uma/contracts-node/dist/packages/contracts-node/typechain/core/ethers";
+import { EventBasedPredictionMarket, ExpandedERC20 } from "../../typechain";
 
-let eventBasedPredictionMarket: Contract, usdc: Contract, collateralWhitelist: Contract;
-let deployer: SignerWithAddress, depositor: SignerWithAddress;
+let eventBasedPredictionMarket: EventBasedPredictionMarket, usdc: Contract, collateralWhitelist: Contract;
+let optimisticOracle: OptimisticOracle;
+let longToken: ExpandedERC20;
+let shortToken: ExpandedERC20;
+let deployer: SignerWithAddress, sponsor: SignerWithAddress, holder: SignerWithAddress;
 
 describe("EventBasedPredictionMarket functions", function () {
-  beforeEach(async function () {
-    [deployer, depositor] = await ethers.getSigners();
-    ({ collateralWhitelist } = await umaEcosystemFixture());
-    ({ eventBasedPredictionMarket, usdc } = await eventBasedPredictionMarketFixture());
+  const proposeAndSettleOptimisticOraclePrice = async (price: BigNumber) => {
+    const ancillaryData = await eventBasedPredictionMarket.customAncillaryData();
+    const identifier = await eventBasedPredictionMarket.priceIdentifier();
+    const expirationTimestamp = await eventBasedPredictionMarket.expirationTimestamp();
+    const optimisticOracleLivenessTime = await eventBasedPredictionMarket.optimisticOracleLivenessTime();
 
-    // mint some fresh tokens for the depositor.
-    await usdc.connect(deployer).mint(depositor.address, amountToSeedWallets);
-    await usdc.connect(deployer).mint(eventBasedPredictionMarket.address, amountToSeedWallets);
+    await optimisticOracle
+      .connect(deployer)
+      .proposePrice(eventBasedPredictionMarket.address, identifier, expirationTimestamp, ancillaryData, price);
+
+    await optimisticOracle
+      .connect(deployer)
+      .setCurrentTime((await optimisticOracle.getCurrentTime()).add(optimisticOracleLivenessTime));
+
+    await optimisticOracle
+      .connect(deployer)
+      .settle(eventBasedPredictionMarket.address, identifier, expirationTimestamp, ancillaryData);
+  };
+
+  beforeEach(async function () {
+    [deployer, sponsor, holder] = await ethers.getSigners();
+
+    ({ collateralWhitelist, optimisticOracle } = await umaEcosystemFixture());
+    ({ eventBasedPredictionMarket, usdc, longToken, shortToken } = await eventBasedPredictionMarketFixture());
+
+    // mint some fresh tokens for the sponsor and deployer.
+    await usdc.connect(deployer).mint(sponsor.address, amountToSeedWallets);
+    await usdc.connect(deployer).mint(deployer.address, amountToSeedWallets);
 
     // Approve the EventBasedPredictionMarket to spend tokens
-    await usdc.connect(depositor).approve(eventBasedPredictionMarket.address, amountToSeedWallets);
+    await usdc.connect(sponsor).approve(eventBasedPredictionMarket.address, amountToSeedWallets);
+    await usdc.connect(deployer).approve(eventBasedPredictionMarket.address, amountToSeedWallets);
 
-    await eventBasedPredictionMarket.connect(depositor).initializeMarket();
+    // Approve the Optimistic Oracle to spend bond tokens
+    await usdc.connect(deployer).approve(optimisticOracle.address, amountToSeedWallets);
+
+    await eventBasedPredictionMarket.connect(deployer).initializeMarket();
   });
-  it("EventBasedPredictionMarket deployment works", async function () {});
+
+  it("Mint, redeem, expire lifecycle", async function () {
+    // Create some sponsor tokens. Send half to the holder account.
+    expect(await usdc.balanceOf(sponsor.address)).to.equal(amountToSeedWallets);
+    expect(await longToken.balanceOf(sponsor.address)).to.equal(0);
+    expect(await shortToken.balanceOf(sponsor.address)).to.equal(0);
+
+    await eventBasedPredictionMarket.connect(sponsor).create(toWei(100));
+    expect(await longToken.balanceOf(sponsor.address)).to.equal(toWei(100));
+    expect(await shortToken.balanceOf(sponsor.address)).to.equal(toWei(100));
+    expect(await usdc.balanceOf(sponsor.address)).to.equal(amountToSeedWallets.sub(toWei(100)));
+
+    // Send half the long tokens to the holder. This would happen by the holder buying them on a dex.
+    await longToken.connect(sponsor).transfer(holder.address, toWei("50"));
+
+    // Token sponsor redeems half their remaining long tokens, along with the associated short tokens.
+    await eventBasedPredictionMarket.connect(sponsor).redeem(toWei("25"));
+
+    // Sponsor should have 25 remaining long tokens and 75 remaining short tokens. They should have been refunded 25 collateral.
+    expect((await usdc.balanceOf(sponsor.address)).toString()).to.equal(
+      amountToSeedWallets.sub(toWei(100)).add(toWei(25))
+    ); // -100 after mint + 25 redeemed.
+    expect(await longToken.balanceOf(sponsor.address)).to.equal(toWei("25"));
+    expect(await shortToken.balanceOf(sponsor.address)).to.equal(toWei("75"));
+
+    // holder should not be able to call redeem as they only have the long token and redemption requires a pair.
+    await expect(eventBasedPredictionMarket.connect(holder).redeem(toWei(25))).to.be.revertedWith(
+      "VM Exception while processing transaction: reverted with reason string 'ERC20: burn amount exceeds balance'"
+    );
+
+    // Propose and settle the optimistic oracle price.
+    // In this case we are answering a YES_OR_NO_QUERY price request with a YES answer.
+    await proposeAndSettleOptimisticOraclePrice(toWei(1));
+
+    // The EventBasedPredictionMarket shouldn't have received the settlement price.
+    expect(await eventBasedPredictionMarket.receivedSettlementPrice()).to.equal(false);
+
+    // Holder redeems his long tokens.
+    await eventBasedPredictionMarket.connect(holder).settle(toWei("50"), 0);
+    expect(await eventBasedPredictionMarket.receivedSettlementPrice()).to.equal(true);
+    expect(await usdc.balanceOf(holder.address)).to.equal(toWei(50)); // holder should have gotten 1 collateral per synthetic.
+    expect(await longToken.balanceOf(holder.address)).to.equal(0); // the long tokens should have been burned.
+
+    // Sponsor redeem remaining tokens. They return the remaining 25 long and 75 short.
+    // Long tokens should return 25 collateral.
+    // Short tokens should return 0 collateral.
+    const initialSponsorBalance = await usdc.balanceOf(sponsor.address);
+    await eventBasedPredictionMarket.connect(sponsor).settle(toWei("25"), toWei("75"));
+    expect(await usdc.balanceOf(sponsor.address)).to.equal(initialSponsorBalance.add(toWei(25)));
+    expect(await longToken.balanceOf(sponsor.address)).to.equal(0);
+    expect(await shortToken.balanceOf(sponsor.address)).to.equal(0);
+
+    // long short pair should have no collateral left in it as everything has been redeemed.
+    expect(await usdc.balanceOf(eventBasedPredictionMarket.address)).to.equal(0);
+  });
 });

--- a/test/eventBasedPredictionMarket/EventBasedPredictionMarket.ts
+++ b/test/eventBasedPredictionMarket/EventBasedPredictionMarket.ts
@@ -1,0 +1,25 @@
+import { SignerWithAddress, expect, Contract, ethers } from "../utils";
+import { umaEcosystemFixture } from "../fixtures/UmaEcosystem.Fixture";
+import { eventBasedPredictionMarketFixture } from "../fixtures/EventBasedPredictionMarket.Fixture";
+import { amountToSeedWallets, amountToDeposit } from "../constants";
+
+let eventBasedPredictionMarket: Contract, usdc: Contract, collateralWhitelist: Contract;
+let deployer: SignerWithAddress, depositor: SignerWithAddress;
+
+describe("EventBasedPredictionMarket functions", function () {
+  beforeEach(async function () {
+    [deployer, depositor] = await ethers.getSigners();
+    ({ collateralWhitelist } = await umaEcosystemFixture());
+    ({ eventBasedPredictionMarket, usdc } = await eventBasedPredictionMarketFixture());
+
+    // mint some fresh tokens for the depositor.
+    await usdc.connect(deployer).mint(depositor.address, amountToSeedWallets);
+    await usdc.connect(deployer).mint(eventBasedPredictionMarket.address, amountToSeedWallets);
+
+    // Approve the EventBasedPredictionMarket to spend tokens
+    await usdc.connect(depositor).approve(eventBasedPredictionMarket.address, amountToSeedWallets);
+
+    await eventBasedPredictionMarket.connect(depositor).initializeMarket();
+  });
+  it("EventBasedPredictionMarket deployment works", async function () {});
+});

--- a/test/fixtures/EventBasedPredictionMarket.Fixture.ts
+++ b/test/fixtures/EventBasedPredictionMarket.Fixture.ts
@@ -1,4 +1,3 @@
-import { BinaryOptionLongShortPairFinancialProductLibrary } from "@uma/contracts-node/dist/packages/contracts-node/typechain/core/ethers";
 import hre from "hardhat";
 import Web3 from "web3";
 import { EventBasedPredictionMarket, ExpandedERC20 } from "../../typechain";
@@ -25,27 +24,17 @@ export async function deployEventBasedPredictionMarket(ethers: any) {
   // Sets collateral as approved in the UMA collateralWhitelist.
   await parentFixture.collateralWhitelist.addToWhitelist(usdc.address);
 
-  const financialProductLibrary = (await (
-    await getContractFactory("BinaryOptionLongShortPairFinancialProductLibrary", deployer)
-  ).deploy()) as BinaryOptionLongShortPairFinancialProductLibrary;
-
-  const constructorParams = {
-    pairName: "will it rain today?",
-    priceIdentifier: identifier,
-    collateralToken: usdc.address,
-    financialProductLibrary: financialProductLibrary.address,
-    customAncillaryData: utf8ToHex("some-address-field:0x1234"),
-    finder: parentFixture.finder.address,
-    timerAddress: parentFixture.timer.address,
-  };
-
   // Deploy the EventBasedPredictionMarket contract.
   const eventBasedPredictionMarket = (await (
     await getContractFactory("EventBasedPredictionMarket", deployer)
-  ).deploy(constructorParams)) as EventBasedPredictionMarket;
-
-  // Set long short pair parameters in the financial product library
-  await financialProductLibrary.setLongShortPairParameters(eventBasedPredictionMarket.address, 1);
+  ).deploy(
+    "will it rain today?",
+    identifier,
+    usdc.address,
+    utf8ToHex("some-address-field:0x1234"),
+    parentFixture.finder.address,
+    parentFixture.timer.address
+  )) as EventBasedPredictionMarket;
 
   // connect to existing ExpandedERC20 contract with ether
   const longToken = (await (
@@ -62,6 +51,5 @@ export async function deployEventBasedPredictionMarket(ethers: any) {
     deployer,
     longToken,
     shortToken,
-    financialProductLibrary,
   };
 }

--- a/test/fixtures/EventBasedPredictionMarket.Fixture.ts
+++ b/test/fixtures/EventBasedPredictionMarket.Fixture.ts
@@ -1,0 +1,46 @@
+import hre from "hardhat";
+import Web3 from "web3";
+import { identifier, TokenRolesEnum } from "../constants";
+import { getContractFactory } from "../utils";
+import { umaEcosystemFixture } from "./UmaEcosystem.Fixture";
+const { utf8ToHex } = Web3.utils;
+
+export const eventBasedPredictionMarketFixture = hre.deployments.createFixture(async ({ ethers }) => {
+  return await deployEventBasedPredictionMarket(ethers);
+});
+
+export async function deployEventBasedPredictionMarket(ethers: any) {
+  const [deployer] = await ethers.getSigners();
+
+  // This fixture is dependent on the UMA ecosystem fixture. Run it first and grab the output. This is used in the
+  // deployments that follows. The output is spread when returning contract instances from this fixture.
+  const parentFixture = await umaEcosystemFixture();
+
+  // deploys collateral for EventBasedPredictionMarket contract
+  const usdc = await (await getContractFactory("ExpandedERC20", deployer)).deploy("USD Coin", "USDC", 6);
+  await usdc.addMember(TokenRolesEnum.MINTER, deployer.address);
+
+  // Sets collateral as approved in the UMA collateralWhitelist.
+  await parentFixture.collateralWhitelist.addToWhitelist(usdc.address);
+
+  const longShortPairFinancialProjectLibraryTest = await (
+    await getContractFactory("LongShortPairFinancialProjectLibraryTest", deployer)
+  ).deploy();
+
+  const constructorParams = {
+    pairName: "will it rain today?",
+    priceIdentifier: identifier,
+    collateralToken: usdc.address,
+    financialProductLibrary: longShortPairFinancialProjectLibraryTest.address,
+    customAncillaryData: utf8ToHex("some-address-field:0x1234"),
+    finder: parentFixture.finder.address,
+    timerAddress: parentFixture.timer.address,
+  };
+
+  // Deploy the EventBasedPredictionMarket contract.
+  const eventBasedPredictionMarket = await (
+    await getContractFactory("EventBasedPredictionMarket", deployer)
+  ).deploy(constructorParams);
+
+  return { ...parentFixture, usdc, eventBasedPredictionMarket, deployer };
+}

--- a/test/fixtures/UmaEcosystem.Fixture.ts
+++ b/test/fixtures/UmaEcosystem.Fixture.ts
@@ -1,6 +1,7 @@
 import { getContractFactory, utf8ToHex, hre } from "../utils";
 import { proposalLiveness, zeroRawValue, identifier } from "../constants";
 import { interfaceName } from "@uma/common";
+import { OptimisticOracle } from "@uma/contracts-node/dist/packages/contracts-node/typechain/core/ethers";
 
 export const umaEcosystemFixture = hre.deployments.createFixture(async ({ ethers }) => {
   const [deployer] = await ethers.getSigners();
@@ -14,9 +15,9 @@ export const umaEcosystemFixture = hre.deployments.createFixture(async ({ ethers
   const mockOracle = await (
     await getContractFactory("MockOracleAncillary", deployer)
   ).deploy(finder.address, timer.address);
-  const optimisticOracle = await (
+  const optimisticOracle = (await (
     await getContractFactory("OptimisticOracle", deployer)
-  ).deploy(proposalLiveness, finder.address, timer.address);
+  ).deploy(proposalLiveness, finder.address, timer.address)) as OptimisticOracle;
 
   // Set all the contracts within the finder.
   await finder.changeImplementationAddress(utf8ToHex(interfaceName.CollateralWhitelist), collateralWhitelist.address);

--- a/yarn.lock
+++ b/yarn.lock
@@ -196,6 +196,11 @@
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
+"@colors/colors@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
 "@cspotcode/source-map-consumer@0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
@@ -207,6 +212,15 @@
   integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
   dependencies:
     "@cspotcode/source-map-consumer" "0.8.0"
+
+"@dabh/diagnostics@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.3.tgz#7f7e97ee9a725dffc7808d93668cc984e1dc477a"
+  integrity sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==
+  dependencies:
+    colorspace "1.1.x"
+    enabled "2.0.x"
+    kuler "^2.0.0"
 
 "@ensdomains/address-encoder@^0.1.7":
   version "0.1.9"
@@ -2065,6 +2079,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/ethereum-protocol@^1.0.0":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@types/ethereum-protocol/-/ethereum-protocol-1.0.2.tgz#e765d4c6f4b5ebe906932bd20333e307c56a9bc7"
+  integrity sha512-Ri/hwt4UckZlF7eqhhAQcXsNvcgQmSJOKZteLco1/5NsRcneW/cJuQcrQNILN2Ohs9WUQjeGW3ZRRNqkEVMzuQ==
+  dependencies:
+    bignumber.js "7.2.1"
+
 "@types/form-data@0.0.33":
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-0.0.33.tgz#c9ac85b2a5fd18435b8c85d9ecb50e6d6c893ff8"
@@ -2298,7 +2319,7 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
-"@uma/common@^2.17.0", "@uma/common@^2.19.0":
+"@uma/common@^2.19.0":
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/@uma/common/-/common-2.19.0.tgz#4ecca9fccbcbead55dbdfdae180b694af62a5f49"
   integrity sha512-b9NiUSyVFXOXH3B2g6ZcwCv7bP2oX7c2EVskERhsbELNUi2SkmbKF7ivBQhRwbFRZGClply8e89z14E6Zi73Pw==
@@ -2335,10 +2356,47 @@
     truffle-deploy-registry "^0.5.1"
     web3 "^1.6.0"
 
-"@uma/contracts-node@^0.2.0":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@uma/contracts-node/-/contracts-node-0.2.1.tgz#29ebba6b2ecba7f0d2dc9b484bc34f0abbdefdaa"
-  integrity sha512-7wPkH/m8tD8UMLYUjSXN5gSp/5NsuPRF1icmwXNTWlhp/Mg4qmJHeANjsWP9JCDxlgdSDixA4hJ5qhVOPXFniA==
+"@uma/common@^2.20.0":
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/@uma/common/-/common-2.20.0.tgz#f211a00257a44880858af440d5328f026c4006ca"
+  integrity sha512-tJk9akdwudq/J4BfuZQ38XCkJFtjZdkT5fcDkmojPuR6gbtWTy5RnP3549kN01ve1QV5c+zqzgRCTHihxRlG8Q==
+  dependencies:
+    "@across-protocol/contracts" "^0.1.4"
+    "@eth-optimism/hardhat-ovm" "^0.2.2"
+    "@ethersproject/bignumber" "^5.0.5"
+    "@google-cloud/kms" "^2.3.1"
+    "@google-cloud/storage" "^5.8.5"
+    "@nomiclabs/hardhat-ethers" "^2.0.2"
+    "@nomiclabs/hardhat-etherscan" "^3.0.0"
+    "@nomiclabs/hardhat-web3" "^2.0.0"
+    "@truffle/contract" "^4.3.38"
+    "@truffle/hdwallet-provider" eip1559-beta
+    "@types/ethereum-protocol" "^1.0.0"
+    "@umaprotocol/truffle-ledger-provider" "^1.0.5"
+    "@uniswap/v3-core" "^1.0.0-rc.2"
+    abi-decoder "github:UMAprotocol/abi-decoder"
+    bignumber.js "^8.0.1"
+    chalk-pipe "^3.0.0"
+    decimal.js "^10.2.1"
+    dotenv "^9.0.0"
+    eth-crypto "^1.7.0"
+    hardhat-deploy "0.9.1"
+    hardhat-gas-reporter "^1.0.4"
+    hardhat-typechain "^0.3.5"
+    lodash.uniqby "^4.7.0"
+    minimist "^1.2.0"
+    moment "^2.24.0"
+    node-metamask "github:UMAprotocol/node-metamask"
+    require-context "^1.1.0"
+    solidity-coverage "^0.7.13"
+    truffle-deploy-registry "^0.5.1"
+    web3 "^1.6.0"
+    winston "^3.2.1"
+
+"@uma/contracts-node@^0.3.7":
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/@uma/contracts-node/-/contracts-node-0.3.7.tgz#d2a1afefc021c70b6565558b24cf5fd082b493fd"
+  integrity sha512-mzI7sv+W91Cm7TBjkMioKg0pvHEOgT8QMlCNPmuQtkxUNqMnNJCj6MLzzotF4c6i3YzHsmA+PbiSsh2jVbhftw==
 
 "@uma/core@^2.18.0":
   version "2.25.1"
@@ -2898,6 +2956,11 @@ async@^2.0.1, async@^2.1.2, async@^2.4.0, async@^2.5.0, async@^2.6.1:
   integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
   dependencies:
     lodash "^4.17.14"
+
+async@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
+  integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -3553,7 +3616,7 @@ bignumber.js@*, bignumber.js@^9.0.0, bignumber.js@^9.0.1:
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.2.tgz#71c6c6bed38de64e24a65ebe16cfcf23ae693673"
   integrity sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==
 
-bignumber.js@^7.2.1:
+bignumber.js@7.2.1, bignumber.js@^7.2.1:
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
   integrity sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==
@@ -4229,7 +4292,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0:
+color-convert@^1.9.0, color-convert@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -4248,15 +4311,39 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.6.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@^3.1.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
+  integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
+  dependencies:
+    color-convert "^1.9.3"
+    color-string "^1.6.0"
 
 colors@1.4.0, colors@^1.1.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
+colorspace@1.1.x:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.4.tgz#8d442d1186152f60453bf8070cd66eb364e59243"
+  integrity sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==
+  dependencies:
+    color "^3.1.3"
+    text-hex "1.0.x"
 
 combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
@@ -5015,6 +5102,11 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
+enabled@2.0.x:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
+  integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
+
 encode-utf8@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/encode-utf8/-/encode-utf8-1.0.3.tgz#f30fdd31da07fb596f281beb2f6b027851994cda"
@@ -5693,15 +5785,7 @@ ethereumjs-abi@0.6.5:
     bn.js "^4.10.0"
     ethereumjs-util "^4.3.0"
 
-ethereumjs-abi@0.6.8, ethereumjs-abi@^0.6.8:
-  version "0.6.8"
-  resolved "https://registry.yarnpkg.com/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz#71bc152db099f70e62f108b7cdfca1b362c6fcae"
-  integrity sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==
-  dependencies:
-    bn.js "^4.11.8"
-    ethereumjs-util "^6.0.0"
-
-"ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
+ethereumjs-abi@0.6.8, ethereumjs-abi@^0.6.8, "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
   version "0.6.8"
   resolved "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0"
   dependencies:
@@ -6248,6 +6332,11 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
+fecha@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.3.tgz#4d9ccdbc61e8629b259fdca67e65891448d569fd"
+  integrity sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==
+
 fetch-ponyfill@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz#ae3ce5f732c645eab87e4ae8793414709b239893"
@@ -6401,6 +6490,11 @@ fmix@^0.1.0:
   integrity sha1-x7vxJN7ELJ0ZHPuUfQqXeN2YbAw=
   dependencies:
     imul "^1.0.0"
+
+fn.name@1.x.x:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
+  integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
 follow-redirects@^1.12.1, follow-redirects@^1.14.0:
   version "1.14.9"
@@ -7604,6 +7698,11 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
+
 is-bigint@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.4.tgz#08147a1875bc2b32005d41ccd8291dffc6691df3"
@@ -8269,6 +8368,11 @@ klaw@^1.0.0:
   optionalDependencies:
     graceful-fs "^4.1.9"
 
+kuler@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
+  integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
+
 lcid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
@@ -8614,6 +8718,17 @@ log-symbols@4.1.0:
   dependencies:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
+
+logform@^2.3.2, logform@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-2.4.0.tgz#131651715a17d50f09c2a2c1a524ff1a4164bcfe"
+  integrity sha512-CPSJw4ftjf517EhXZGGvTHHkYobo7ZCc0kvwUoOYcjfR2UVrI66RHj8MCrfAdEitdmFqbu2BYdYs8FHHZSb6iw==
+  dependencies:
+    "@colors/colors" "1.5.0"
+    fecha "^4.2.0"
+    ms "^2.1.1"
+    safe-stable-stringify "^2.3.1"
+    triple-beam "^1.3.0"
 
 long@^4.0.0:
   version "4.0.0"
@@ -9580,6 +9695,13 @@ once@1.x, once@^1.3.0, once@^1.3.1, once@^1.4.0:
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
+
+one-time@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/one-time/-/one-time-1.0.0.tgz#e06bc174aed214ed58edede573b433bbf827cb45"
+  integrity sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==
+  dependencies:
+    fn.name "1.x.x"
 
 onetime@^5.1.0:
   version "5.1.2"
@@ -10790,6 +10912,11 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
+safe-stable-stringify@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz#ab67cbe1fe7d40603ca641c5e765cb942d04fc73"
+  integrity sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg==
+
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
@@ -11113,6 +11240,13 @@ simple-get@^3.0.3:
     once "^1.3.1"
     simple-concat "^1.0.0"
 
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
+  dependencies:
+    is-arrayish "^0.3.1"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -11356,6 +11490,11 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
+
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
 
 stacktrace-parser@^0.1.10:
   version "0.1.10"
@@ -11744,6 +11883,11 @@ testrpc@0.0.1:
   resolved "https://registry.yarnpkg.com/testrpc/-/testrpc-0.0.1.tgz#83e2195b1f5873aec7be1af8cbe6dcf39edb7aed"
   integrity sha512-afH1hO+SQ/VPlmaLUFj2636QMeDvPCeQMc/9RBMW0IfjNe9gFD9Ra3ShqYkB7py0do1ZcCna/9acHyzTJ+GcNA==
 
+text-hex@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
+  integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -11875,6 +12019,11 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
+
+triple-beam@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
+  integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
 
 "true-case-path@^2.2.1":
   version "2.2.1"
@@ -13463,6 +13612,31 @@ window-size@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
   integrity sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=
+
+winston-transport@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.5.0.tgz#6e7b0dd04d393171ed5e4e4905db265f7ab384fa"
+  integrity sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==
+  dependencies:
+    logform "^2.3.2"
+    readable-stream "^3.6.0"
+    triple-beam "^1.3.0"
+
+winston@^3.2.1:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.7.2.tgz#95b4eeddbec902b3db1424932ac634f887c400b1"
+  integrity sha512-QziIqtojHBoyzUOdQvQiar1DH0Xp9nF1A1y7NVy2DGEsz82SBDtOalS0ulTRGVT14xPX3WRWkCsdcJKqNflKng==
+  dependencies:
+    "@dabh/diagnostics" "^2.0.2"
+    async "^3.2.3"
+    is-stream "^2.0.0"
+    logform "^2.4.0"
+    one-time "^1.0.0"
+    readable-stream "^3.4.0"
+    safe-stable-stringify "^2.3.1"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.5.0"
 
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
Add EventBasedPredictionMarket contract to showcase how to use the event based price requests of the optimist oracle.

Changes proposed in this pool request:

- Add EventBasedPredictionMarket smart contract to create a binary prediction market with long a short tokens giving exposition to both sides of the market. It makes use of the optimistic oracle's event-based price request, which allows for quick proposer reward refunds in the event of a dispute and, as a result, the possibility of auto re-requesting price.
- Added fixture for the new contract
- Added tests for new contract