### PR TITLE
fix: rejected disputes can settle

### DIFF
--- a/contracts/EventBasedPredictionMarket.sol
+++ b/contracts/EventBasedPredictionMarket.sol
@@ -135,7 +135,6 @@ contract EventBasedPredictionMarket is Testable {
         OptimisticOracleV2Interface optimisticOracle = getOptimisticOracle();
         require(msg.sender == address(optimisticOracle), "not authorized");
 
-        require(timestamp == expirationTimestamp, "different timestamps");
         require(identifier == priceIdentifier, "same identifier");
         require(keccak256(ancillaryData) == keccak256(customAncillaryData), "same ancillary data");
 

--- a/contracts/EventBasedPredictionMarket.sol
+++ b/contracts/EventBasedPredictionMarket.sol
@@ -138,6 +138,9 @@ contract EventBasedPredictionMarket is Testable {
         require(identifier == priceIdentifier, "same identifier");
         require(keccak256(ancillaryData) == keccak256(customAncillaryData), "same ancillary data");
 
+        // We only want to process the price if it is for the current price request.
+        if (timestamp != expirationTimestamp) return;
+
         // Calculate the value of settlementPrice using either 0, 0.5e18, or 1e18 as the expiryPrice.
         if (price >= 1e18) {
             settlementPrice = 1e18;

--- a/test/EventBasedPredictionMarket.ts
+++ b/test/EventBasedPredictionMarket.ts
@@ -215,7 +215,7 @@ describe("EventBasedPredictionMarket functions", function () {
     expect(await usdc.balanceOf(sponsor.address)).to.equal(sponsorInitialBalance.add(toWei(100)));
   });
 
-  it("Erroneously disputed price requests can be settled, as well as auto-requested price requests.", async function () {
+  it("Rejected disputed price requests can be settled, as well as auto-requested price requests.", async function () {
     const requestSubmissionTimestamp = await eventBasedPredictionMarket.expirationTimestamp();
     const proposalSubmissionTimestamp = parseInt(requestSubmissionTimestamp.toString()) + 100;
     await optimisticOracle.setCurrentTime(proposalSubmissionTimestamp);

--- a/test/fixtures/UmaEcosystem.Fixture.ts
+++ b/test/fixtures/UmaEcosystem.Fixture.ts
@@ -1,7 +1,7 @@
 import { getContractFactory, utf8ToHex, hre } from "../utils";
 import { proposalLiveness, zeroRawValue, identifier } from "../constants";
 import { interfaceName } from "@uma/common";
-import { OptimisticOracleV2Ethers } from "@uma/contracts-node";
+import { OptimisticOracleV2Ethers, MockOracleAncillaryEthers } from "@uma/contracts-node";
 
 export const umaEcosystemFixture = hre.deployments.createFixture(async ({ ethers }) => {
   const [deployer] = await ethers.getSigners();
@@ -12,9 +12,9 @@ export const umaEcosystemFixture = hre.deployments.createFixture(async ({ ethers
   const collateralWhitelist = await (await getContractFactory("AddressWhitelist", deployer)).deploy();
   const identifierWhitelist = await (await getContractFactory("IdentifierWhitelist", deployer)).deploy();
   const store = await (await getContractFactory("Store", deployer)).deploy(zeroRawValue, zeroRawValue, timer.address);
-  const mockOracle = await (
+  const mockOracle = (await (
     await getContractFactory("MockOracleAncillary", deployer)
-  ).deploy(finder.address, timer.address);
+  ).deploy(finder.address, timer.address)) as MockOracleAncillaryEthers;
   const optimisticOracle = (await (
     await getContractFactory("OptimisticOracleV2", deployer)
   ).deploy(proposalLiveness, finder.address, timer.address)) as OptimisticOracleV2Ethers;


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

Changes proposed:

- Remove unnecessary require that was preventing rejected disputes to settle 
- Check if the price settled is the one from the last price request and act accordingly 