### PR TITLE
fix: rename expirationTimestamp

### DIFF
--- a/test/EventBasedPredictionMarket/EventBasedPredictionMarket.Lifecycle.ts
+++ b/test/EventBasedPredictionMarket/EventBasedPredictionMarket.Lifecycle.ts
@@ -80,13 +80,13 @@ describe("EventBasedPredictionMarket: Lifecycle", function () {
   it("Early expiring is not allowed", async function () {
     const ancillaryData = await eventBasedPredictionMarket.customAncillaryData();
     const identifier = await eventBasedPredictionMarket.priceIdentifier();
-    const expirationTimestamp = await eventBasedPredictionMarket.expirationTimestamp();
+    const requestTimestamp = await eventBasedPredictionMarket.requestTimestamp();
 
     await expect(
       optimisticOracle.proposePrice(
         eventBasedPredictionMarket.address,
         identifier,
-        expirationTimestamp,
+        requestTimestamp,
         ancillaryData,
         MIN_INT_VALUE
       )

--- a/test/EventBasedPredictionMarket/helpers.ts
+++ b/test/EventBasedPredictionMarket/helpers.ts
@@ -6,18 +6,18 @@ export const proposeAndSettleOptimisticOraclePrice = async (
 ) => {
   const ancillaryData = await eventBasedPredictionMarket.customAncillaryData();
   const identifier = await eventBasedPredictionMarket.priceIdentifier();
-  const expirationTimestamp = await eventBasedPredictionMarket.expirationTimestamp();
+  const requestTimestamp = await eventBasedPredictionMarket.requestTimestamp();
   const optimisticOracleLivenessTime = await eventBasedPredictionMarket.optimisticOracleLivenessTime();
 
   await optimisticOracle.proposePrice(
     eventBasedPredictionMarket.address,
     identifier,
-    expirationTimestamp,
+    requestTimestamp,
     ancillaryData,
     price
   );
 
   await optimisticOracle.setCurrentTime((await optimisticOracle.getCurrentTime()).add(optimisticOracleLivenessTime));
 
-  await optimisticOracle.settle(eventBasedPredictionMarket.address, identifier, expirationTimestamp, ancillaryData);
+  await optimisticOracle.settle(eventBasedPredictionMarket.address, identifier, requestTimestamp, ancillaryData);
 };


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

Changes proposed in this PR:

- Rename `expirationTimestamp` to `requestTimestamp` to be more consistent with the event based pattern