### PR TITLE
feat: simplify insurance arbitrator

### DIFF
--- a/contracts/InsuranceArbitrator.sol
+++ b/contracts/InsuranceArbitrator.sol
@@ -43,8 +43,7 @@ contract InsuranceArbitrator {
     // Oracle proposal bond set to 0.1% of claimed insurance coverage.
     uint256 public constant oracleBondPercentage = 1e15;
 
-    // Optimistic oracle liveness set to 24h.
-    uint256 public constant optimisticOracleLivenessTime = 3600 * 24;
+    uint256 public constant optimisticOracleLivenessTime = 3600 * 24; // Optimistic oracle liveness set to 24h.
 
     // Price identifier to use when requesting claims through Optimistic Oracle.
     bytes32 public constant priceIdentifier = "YES_OR_NO_QUERY";
@@ -54,14 +53,11 @@ contract InsuranceArbitrator {
     string constant ancillaryDataHead = 'q:"Had the following insured event occurred as of request timestamp: ';
     string constant ancillaryDataTail = '?"';
 
-    // Finder for UMA contracts.
-    FinderInterface public immutable finder;
+    FinderInterface public immutable finder; // Finder for UMA contracts.
 
-    // Optimistic Oracle instance where claims are resolved.
-    OptimisticOracleV2Interface public immutable oo;
+    OptimisticOracleV2Interface public immutable oo; // Optimistic Oracle instance where claims are resolved.
 
-    // Denomination token for insurance coverage and bonding.
-    IERC20 public immutable currency;
+    IERC20 public immutable currency; // Denomination token for insurance coverage and bonding.
 
     uint256 public constant MAX_EVENT_DESCRIPTION_SIZE = 300; // Insured event description should be concise.
 

--- a/contracts/InsuranceArbitrator.sol
+++ b/contracts/InsuranceArbitrator.sol
@@ -41,7 +41,8 @@ contract InsuranceArbitrator {
     mapping(bytes32 => bytes32) public insuranceClaims;
 
     // Oracle proposal bond set to 0.1% of claimed insurance coverage.
-    uint256 public constant oracleBondPercentage = 1e15;
+    uint256 public constant oracleBondPercentage = 0.001e18; // Oracle proposal bond set to 0.1% of claimed insurance coverage.
+
 
     uint256 public constant optimisticOracleLivenessTime = 3600 * 24; // Optimistic oracle liveness set to 24h.
 

--- a/contracts/InsuranceArbitrator.sol
+++ b/contracts/InsuranceArbitrator.sol
@@ -164,13 +164,12 @@ contract InsuranceArbitrator {
      * @notice Callback function called by the Optimistic Oracle when the claim is settled. If the claim is confirmed
      * this pays out insurance coverage to the insured beneficiary and deletes the insurance policy. If the claim is
      * rejected policy claim state is reset so that it is ready for the subsequent claim attempts.
-     * @param identifier Price identifier being requested.
      * @param timestamp Timestamp of the price being requested.
      * @param ancillaryData Ancillary data of the price being requested.
      * @param price Price that was resolved by the escalation process.
      */
     function priceSettled(
-        bytes32 identifier,
+        bytes32, // identifier passed by Optimistic Oracle, but not used here as it is always the same.
         uint256 timestamp,
         bytes memory ancillaryData,
         int256 price

--- a/contracts/InsuranceArbitrator.sol
+++ b/contracts/InsuranceArbitrator.sol
@@ -72,27 +72,9 @@ contract InsuranceArbitrator {
         address indexed insuredAddress,
         uint256 insuredAmount
     );
-    event ClaimSubmitted(
-        uint256 claimTimestamp,
-        bytes32 indexed policyId,
-        string insuredEvent,
-        address indexed insuredAddress,
-        uint256 insuredAmount
-    );
-    event ClaimAccepted(
-        uint256 claimTimestamp,
-        bytes32 indexed policyId,
-        string insuredEvent,
-        address indexed insuredAddress,
-        uint256 insuredAmount
-    );
-    event ClaimRejected(
-        uint256 claimTimestamp,
-        bytes32 indexed policyId,
-        string insuredEvent,
-        address indexed insuredAddress,
-        uint256 insuredAmount
-    );
+    event ClaimSubmitted(uint256 claimTimestamp, bytes32 indexed claimId, bytes32 indexed policyId);
+    event ClaimAccepted(bytes32 indexed claimId, bytes32 indexed policyId);
+    event ClaimRejected(bytes32 indexed claimId, bytes32 indexed policyId);
 
     /**
      * @notice Construct the InsuranceArbitrator
@@ -173,7 +155,7 @@ contract InsuranceArbitrator {
         currency.safeApprove(address(oo), totalBond);
         oo.proposePriceFor(msg.sender, address(this), priceIdentifier, timestamp, ancillaryData, int256(1e18));
 
-        emit ClaimSubmitted(timestamp, policyId, insuredEvent, claimedPolicy.insuredAddress, insuredAmount);
+        emit ClaimSubmitted(timestamp, claimId, policyId);
     }
 
     /******************************************
@@ -201,7 +183,6 @@ contract InsuranceArbitrator {
         // Claim can be settled only once, thus should be deleted.
         bytes32 policyId = insuranceClaims[claimId];
         InsurancePolicy storage claimedPolicy = insurancePolicies[policyId];
-        string memory insuredEvent = claimedPolicy.insuredEvent;
         delete insuranceClaims[claimId];
 
         address insuredAddress = claimedPolicy.insuredAddress;
@@ -212,12 +193,12 @@ contract InsuranceArbitrator {
             delete insurancePolicies[policyId];
             currency.safeTransfer(insuredAddress, insuredAmount);
 
-            emit ClaimAccepted(timestamp, policyId, insuredEvent, insuredAddress, insuredAmount);
+            emit ClaimAccepted(claimId, policyId);
             // Otherwise just reset the flag so that repeated claims can be made.
         } else {
             claimedPolicy.claimInitiated = false;
 
-            emit ClaimRejected(timestamp, policyId, insuredEvent, insuredAddress, insuredAmount);
+            emit ClaimRejected(claimId, policyId);
         }
     }
 

--- a/contracts/InsuranceArbitrator.sol
+++ b/contracts/InsuranceArbitrator.sol
@@ -40,9 +40,7 @@ contract InsuranceArbitrator {
     // This is used in callback function to potentially pay out the beneficiary.
     mapping(bytes32 => bytes32) public insuranceClaims;
 
-    // Oracle proposal bond set to 0.1% of claimed insurance coverage.
-    uint256 public constant oracleBondPercentage = 0.001e18; // Oracle proposal bond set to 0.1% of claimed insurance coverage.
-
+    uint256 public constant oracleBondPercentage = 0.001e18; // Proposal bond set to 0.1% of claimed insurance coverage.
 
     uint256 public constant optimisticOracleLivenessTime = 3600 * 24; // Optimistic oracle liveness set to 24h.
 

--- a/contracts/InsuranceArbitrator.sol
+++ b/contracts/InsuranceArbitrator.sol
@@ -62,7 +62,7 @@ contract InsuranceArbitrator {
     string constant ancillaryDataTail = '?"';
 
     // Finder for UMA contracts.
-    FinderInterface public finder;
+    FinderInterface public immutable finder;
 
     uint256 public constant MAX_EVENT_DESCRIPTION_SIZE = 300; // Insured event description should be concise.
 

--- a/contracts/InsuranceArbitrator.sol
+++ b/contracts/InsuranceArbitrator.sol
@@ -41,7 +41,7 @@ contract InsuranceArbitrator {
     mapping(bytes32 => bytes32) public insuranceClaims;
 
     // Oracle proposal bond set to 0.1% of claimed insurance coverage.
-    uint256 constant oracleBondPercentage = 1e15;
+    uint256 public constant oracleBondPercentage = 1e15;
 
     // Optimistic oracle liveness set to 24h.
     uint256 public constant optimisticOracleLivenessTime = 3600 * 24;


### PR DESCRIPTION
This aims at shortening lines of code for demonstration purposes, most notably:
- use immutable OO implementation for all claims and shorten name to `oo`
- use immutable currency for all insurance policies
- use inline comments where possible
- reduce information logged in events
- avoid creating memory variables and reading directly from storage