### PR TITLE
test: insurance arbitrator

### DIFF
--- a/contracts/InsuranceArbitrator.sol
+++ b/contracts/InsuranceArbitrator.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import "@uma/core/contracts/common/implementation/AddressWhitelist.sol";
 import "@uma/core/contracts/oracle/implementation/Constants.sol";
+import "@uma/core/contracts/common/implementation/Testable.sol";
 import "@uma/core/contracts/oracle/interfaces/FinderInterface.sol";
 import "@uma/core/contracts/oracle/interfaces/OptimisticOracleV2Interface.sol";
 
@@ -18,7 +19,7 @@ import "@uma/core/contracts/oracle/interfaces/OptimisticOracleV2Interface.sol";
  * automatically pays out insurance coverage to the insured beneficiary. If the claim is rejected policy continues to be
  * active ready for the subsequent claim attempts.
  */
-contract InsuranceArbitrator {
+contract InsuranceArbitrator is Testable {
     using SafeERC20 for IERC20;
 
     /******************************************
@@ -107,7 +108,7 @@ contract InsuranceArbitrator {
      * @notice Construct the InsuranceArbitrator
      * @param _finderAddress DVM finder to find other UMA ecosystem contracts.
      */
-    constructor(address _finderAddress) {
+    constructor(address _finderAddress, address _timerAddress) Testable(_timerAddress) {
         finder = FinderInterface(_finderAddress);
     }
 
@@ -162,7 +163,7 @@ contract InsuranceArbitrator {
         require(!claimedPolicy.claimInitiated, "Claim already initiated");
 
         claimedPolicy.claimInitiated = true;
-        uint256 timestamp = block.timestamp;
+        uint256 timestamp = getCurrentTime();
         string memory insuredEvent = claimedPolicy.insuredEvent;
         bytes memory ancillaryData = abi.encodePacked(ancillaryDataHead, insuredEvent, ancillaryDataTail);
         bytes32 claimId = _getClaimId(timestamp, ancillaryData);

--- a/contracts/InsuranceArbitrator.sol
+++ b/contracts/InsuranceArbitrator.sol
@@ -78,15 +78,16 @@ contract InsuranceArbitrator is Testable {
 
     /**
      * @notice Construct the InsuranceArbitrator
-     * @param _finderAddress DVM finder to find other UMA ecosystem contracts.
+     * @param _finder DVM finder to find other UMA ecosystem contracts.
      * @param _currency denomination token for insurance coverage and bonding.
+     * @param _timer to enable simple time manipulation on this contract to simplify testing.
      */
     constructor(
-        address _finderAddress,
+        FinderInterface _finder,
         address _currency,
-        address _timerAddress
-    ) Testable(_timerAddress) {
-        finder = FinderInterface(_finderAddress);
+        address _timer
+    ) Testable(_timer) {
+        finder = _finder;
         currency = IERC20(_currency);
         oo = OptimisticOracleV2Interface(finder.getImplementationAddress(OracleInterfaces.OptimisticOracleV2));
     }

--- a/deploy/001_deploy_optimistic_deposit_box.ts
+++ b/deploy/001_deploy_optimistic_deposit_box.ts
@@ -13,8 +13,8 @@ const func = async function (hre: HardhatRuntimeEnvironment) {
   const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
   const Finder = await getAddress("Finder", chainId);
-  
-  // Note: The Goerli WETH address is hardcoded as the collateral address. Feel free to change 
+
+  // Note: The Goerli WETH address is hardcoded as the collateral address. Feel free to change
   // if using a different collateral type or deploying to a different network.
   await deploy("OptimisticDepositBox", {
     from: deployer,

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@uma/core": "2.38.0"
   },
   "devDependencies": {
+    "@nomicfoundation/hardhat-chai-matchers": "^1.0.4",
     "@nomiclabs/hardhat-ethers": "^2.2.0",
     "@nomiclabs/hardhat-etherscan": "^3.1.1",
     "@nomiclabs/hardhat-waffle": "^2.0.3",

--- a/test/InsuranceArbitrator/InsuranceArbitrator.Claim.ts
+++ b/test/InsuranceArbitrator/InsuranceArbitrator.Claim.ts
@@ -82,4 +82,15 @@ describe("Insurance Arbitrator: Claim", function () {
       "Insurance not issued"
     );
   });
+  it("Cannot have simultaneous claims on one policy", async function () {
+    // Double funding for the claimer.
+    await usdc.connect(deployer).mint(claimant.address, expectedBond);
+    await usdc.connect(claimant).approve(insuranceArbitrator.address, expectedBond.mul(2));
+
+    // Repeated claim on the same policy should revert.
+    await expect(insuranceArbitrator.connect(claimant).submitClaim(policyId)).not.to.be.reverted;
+    await expect(insuranceArbitrator.connect(claimant).submitClaim(policyId)).to.be.revertedWith(
+      "Claim already initiated"
+    );
+  });
 });

--- a/test/InsuranceArbitrator/InsuranceArbitrator.Claim.ts
+++ b/test/InsuranceArbitrator/InsuranceArbitrator.Claim.ts
@@ -1,7 +1,7 @@
 import { ExpandedERC20Ethers, OptimisticOracleV2Ethers, StoreEthers, TimerEthers } from "@uma/contracts-node";
 import { insuranceArbitratorFixture } from "../fixtures/InsuranceArbitrator.Fixture";
 import { umaEcosystemFixture } from "../fixtures/UmaEcosystem.Fixture";
-import { anyValue, BigNumber, expect, ethers, SignerWithAddress, toWei } from "../utils";
+import { anyValue, BigNumber, expect, ethers, SignerWithAddress, toWei, randomBytes32 } from "../utils";
 import { InsuranceArbitrator } from "../../typechain";
 import { identifier, insuredAmount, insuredEvent, yesPrice } from "./constants";
 import { constructAncillaryData, getClaimIdFromTx, getExpirationTime, getPolicyIdFromTx } from "./utils";
@@ -75,5 +75,11 @@ describe("Insurance Arbitrator: Claim", function () {
     expect(request.proposedPrice).to.equal(yesPrice);
     expect(request.expirationTime).to.equal(expectedExpirationTime);
     expect(request.requestSettings.callbackOnPriceSettled).to.equal(true);
+  });
+  it("Check for valid insurance policy", async function () {
+    const invalidPolicyId = randomBytes32();
+    await expect(insuranceArbitrator.connect(claimant).submitClaim(invalidPolicyId)).to.be.revertedWith(
+      "Insurance not issued"
+    );
   });
 });

--- a/test/InsuranceArbitrator/InsuranceArbitrator.Claim.ts
+++ b/test/InsuranceArbitrator/InsuranceArbitrator.Claim.ts
@@ -3,7 +3,7 @@ import { insuranceArbitratorFixture } from "../fixtures/InsuranceArbitrator.Fixt
 import { umaEcosystemFixture } from "../fixtures/UmaEcosystem.Fixture";
 import { anyValue, BigNumber, expect, ethers, SignerWithAddress, toWei, randomBytes32 } from "../utils";
 import { InsuranceArbitrator } from "../../typechain";
-import { identifier, insuredAmount, insuredEvent, yesPrice } from "./constants";
+import { identifier, insuredAmount, insuredEvent, YES_ANSWER } from "./constants";
 import { constructAncillaryData, getClaimIdFromTx, getExpirationTime, getPolicyIdFromTx } from "./utils";
 
 let insuranceArbitrator: InsuranceArbitrator,
@@ -72,7 +72,7 @@ describe("Insurance Arbitrator: Claim", function () {
     );
     expect(request.proposer).to.equal(claimant.address);
     expect(request.currency).to.equal(usdc.address);
-    expect(request.proposedPrice).to.equal(yesPrice);
+    expect(request.proposedPrice).to.equal(YES_ANSWER);
     expect(request.expirationTime).to.equal(expectedExpirationTime);
     expect(request.requestSettings.callbackOnPriceSettled).to.equal(true);
   });

--- a/test/InsuranceArbitrator/InsuranceArbitrator.Claim.ts
+++ b/test/InsuranceArbitrator/InsuranceArbitrator.Claim.ts
@@ -1,0 +1,79 @@
+import { ExpandedERC20Ethers, OptimisticOracleV2Ethers, StoreEthers, TimerEthers } from "@uma/contracts-node";
+import { insuranceArbitratorFixture } from "../fixtures/InsuranceArbitrator.Fixture";
+import { umaEcosystemFixture } from "../fixtures/UmaEcosystem.Fixture";
+import { anyValue, BigNumber, expect, ethers, SignerWithAddress, toWei } from "../utils";
+import { InsuranceArbitrator } from "../../typechain";
+import { identifier, insuredAmount, insuredEvent, yesPrice } from "./constants";
+import { constructAncillaryData, getClaimIdFromTx, getExpirationTime, getPolicyIdFromTx } from "./utils";
+
+let insuranceArbitrator: InsuranceArbitrator,
+  usdc: ExpandedERC20Ethers,
+  store: StoreEthers,
+  optimisticOracle: OptimisticOracleV2Ethers,
+  timer: TimerEthers;
+let deployer: SignerWithAddress, insurer: SignerWithAddress, insured: SignerWithAddress, claimant: SignerWithAddress;
+let policyId: string;
+let expectedBond: BigNumber;
+let currentTime: BigNumber;
+
+describe("Insurance Arbitrator: Claim", function () {
+  beforeEach(async function () {
+    [deployer, insurer, insured, claimant] = await ethers.getSigners();
+    ({ store, optimisticOracle, timer } = await umaEcosystemFixture());
+    ({ usdc, insuranceArbitrator } = await insuranceArbitratorFixture());
+
+    // Mint and approve insuredAmount tokens for the insurer.
+    await usdc.connect(deployer).mint(insurer.address, insuredAmount);
+    await usdc.connect(insurer).approve(insuranceArbitrator.address, insuredAmount);
+
+    // Issue insurance policy and grab emitted policyId.
+    const issueInsuranceTx = insuranceArbitrator
+      .connect(insurer)
+      .issueInsurance(insuredEvent, insured.address, insuredAmount);
+    policyId = await getPolicyIdFromTx(insuranceArbitrator, issueInsuranceTx);
+
+    // Mint and approve expected proposal bond for the claimant.
+    const finalFee = (await store.computeFinalFee(usdc.address)).rawValue;
+    const oracleBondPercentage = await insuranceArbitrator.oracleBondPercentage();
+    expectedBond = oracleBondPercentage.mul(insuredAmount).div(toWei("1")).add(finalFee);
+    await usdc.connect(deployer).mint(claimant.address, expectedBond);
+    await usdc.connect(claimant).approve(insuranceArbitrator.address, expectedBond);
+  });
+  it("Submitting claim correctly pulls tokens and changes contract state", async function () {
+    const claimantBalanceBefore = await usdc.balanceOf(claimant.address);
+    const ooBalanceBefore = await usdc.balanceOf(optimisticOracle.address);
+
+    // Submit a claim on the insurance policy.
+    const submitClaimTx = insuranceArbitrator.connect(claimant).submitClaim(policyId);
+
+    // Verify emitted transaction log.
+    currentTime = await timer.getCurrentTime();
+    await expect(submitClaimTx)
+      .to.emit(insuranceArbitrator, "ClaimSubmitted")
+      .withArgs(currentTime, anyValue, policyId);
+
+    // Verify proposal bond has been transferred to Optimistic Oracle.
+    expect(await usdc.balanceOf(claimant.address)).to.equal(claimantBalanceBefore.sub(expectedBond));
+    expect(await usdc.balanceOf(optimisticOracle.address)).to.equal(ooBalanceBefore.add(expectedBond));
+
+    // Verify Insurance Arbitrator contract state has updated.
+    const claimId = await getClaimIdFromTx(insuranceArbitrator, submitClaimTx);
+    expect((await insuranceArbitrator.insurancePolicies(policyId)).claimInitiated).to.equal(true);
+    expect(await insuranceArbitrator.insuranceClaims(claimId)).to.equal(policyId);
+
+    // Verify price request state on Optimistic Oracle.
+    const expectedAncillaryData = constructAncillaryData(insuredEvent);
+    const expectedExpirationTime = await getExpirationTime(insuranceArbitrator, currentTime);
+    const request = await optimisticOracle.getRequest(
+      insuranceArbitrator.address,
+      identifier,
+      currentTime,
+      expectedAncillaryData
+    );
+    expect(request.proposer).to.equal(claimant.address);
+    expect(request.currency).to.equal(usdc.address);
+    expect(request.proposedPrice).to.equal(yesPrice);
+    expect(request.expirationTime).to.equal(expectedExpirationTime);
+    expect(request.requestSettings.callbackOnPriceSettled).to.equal(true);
+  });
+});

--- a/test/InsuranceArbitrator/InsuranceArbitrator.Issue.ts
+++ b/test/InsuranceArbitrator/InsuranceArbitrator.Issue.ts
@@ -46,4 +46,11 @@ describe("Insurance Arbitrator: Issue", function () {
     expect(insurancePolicy.insuredAddress).to.equal(insured.address);
     expect(insurancePolicy.insuredAmount).to.equal(insuredAmount);
   });
+  it("Event description limits enforced", async function () {
+    const invalidEventLength = (await insuranceArbitrator.MAX_EVENT_DESCRIPTION_SIZE()).add(1);
+    const invalidInsuredEvent = "X".repeat(Number(invalidEventLength));
+    await expect(
+      insuranceArbitrator.connect(insurer).issueInsurance(invalidInsuredEvent, insured.address, insuredAmount)
+    ).to.revertedWith("Event description too long");
+  });
 });

--- a/test/InsuranceArbitrator/InsuranceArbitrator.Issue.ts
+++ b/test/InsuranceArbitrator/InsuranceArbitrator.Issue.ts
@@ -59,4 +59,9 @@ describe("Insurance Arbitrator: Issue", function () {
       insuranceArbitrator.connect(insurer).issueInsurance(insuredEvent, ZERO_ADDRESS, insuredAmount)
     ).to.revertedWith("Invalid insured address");
   });
+  it("Insured amount verified", async function () {
+    await expect(insuranceArbitrator.connect(insurer).issueInsurance(insuredEvent, insured.address, 0)).to.revertedWith(
+      "Amount should be above 0"
+    );
+  });
 });

--- a/test/InsuranceArbitrator/InsuranceArbitrator.Issue.ts
+++ b/test/InsuranceArbitrator/InsuranceArbitrator.Issue.ts
@@ -27,12 +27,12 @@ describe("Insurance Arbitrator: Issue", function () {
     // Issue new insurance policy.
     const issueInsuranceTx = insuranceArbitrator
       .connect(insurer)
-      .issueInsurance(insuredEvent, insured.address, usdc.address, insuredAmount);
+      .issueInsurance(insuredEvent, insured.address, insuredAmount);
 
     // Verify emitted transaction log.
     await expect(issueInsuranceTx)
       .to.emit(insuranceArbitrator, "PolicyIssued")
-      .withArgs(anyValue, insurer.address, insuredEvent, insured.address, usdc.address, insuredAmount);
+      .withArgs(anyValue, insurer.address, insuredEvent, insured.address, insuredAmount);
 
     // Verify insured amount has been deposited.
     expect(await usdc.balanceOf(insurer.address)).to.equal(insurerBalanceBefore.sub(insuredAmount));
@@ -44,7 +44,6 @@ describe("Insurance Arbitrator: Issue", function () {
     expect(insurancePolicy.claimInitiated).to.equal(false);
     expect(insurancePolicy.insuredEvent).to.equal(insuredEvent);
     expect(insurancePolicy.insuredAddress).to.equal(insured.address);
-    expect(insurancePolicy.currency).to.equal(usdc.address);
     expect(insurancePolicy.insuredAmount).to.equal(insuredAmount);
   });
 });

--- a/test/InsuranceArbitrator/InsuranceArbitrator.Issue.ts
+++ b/test/InsuranceArbitrator/InsuranceArbitrator.Issue.ts
@@ -1,3 +1,4 @@
+import { ZERO_ADDRESS } from "@uma/common";
 import { ExpandedERC20Ethers } from "@uma/contracts-node";
 import { insuranceArbitratorFixture } from "../fixtures/InsuranceArbitrator.Fixture";
 import { umaEcosystemFixture } from "../fixtures/UmaEcosystem.Fixture";
@@ -52,5 +53,10 @@ describe("Insurance Arbitrator: Issue", function () {
     await expect(
       insuranceArbitrator.connect(insurer).issueInsurance(invalidInsuredEvent, insured.address, insuredAmount)
     ).to.revertedWith("Event description too long");
+  });
+  it("Insured address verified", async function () {
+    await expect(
+      insuranceArbitrator.connect(insurer).issueInsurance(insuredEvent, ZERO_ADDRESS, insuredAmount)
+    ).to.revertedWith("Invalid insured address");
   });
 });

--- a/test/InsuranceArbitrator/InsuranceArbitrator.Issue.ts
+++ b/test/InsuranceArbitrator/InsuranceArbitrator.Issue.ts
@@ -52,17 +52,17 @@ describe("Insurance Arbitrator: Issue", function () {
     const invalidInsuredEvent = "X".repeat(Number(invalidEventLength));
     await expect(
       insuranceArbitrator.connect(insurer).issueInsurance(invalidInsuredEvent, insured.address, insuredAmount)
-    ).to.revertedWith("Event description too long");
+    ).to.be.revertedWith("Event description too long");
   });
   it("Insured address verified", async function () {
     await expect(
       insuranceArbitrator.connect(insurer).issueInsurance(insuredEvent, ZERO_ADDRESS, insuredAmount)
-    ).to.revertedWith("Invalid insured address");
+    ).to.be.revertedWith("Invalid insured address");
   });
   it("Insured amount verified", async function () {
-    await expect(insuranceArbitrator.connect(insurer).issueInsurance(insuredEvent, insured.address, 0)).to.revertedWith(
-      "Amount should be above 0"
-    );
+    await expect(
+      insuranceArbitrator.connect(insurer).issueInsurance(insuredEvent, insured.address, 0)
+    ).to.be.revertedWith("Amount should be above 0");
   });
   it("Cannot issue the same policy in one block", async function () {
     // Double funding for the insurer.

--- a/test/InsuranceArbitrator/InsuranceArbitrator.Issue.ts
+++ b/test/InsuranceArbitrator/InsuranceArbitrator.Issue.ts
@@ -3,21 +3,17 @@ import { insuranceArbitratorFixture } from "../fixtures/InsuranceArbitrator.Fixt
 import { umaEcosystemFixture } from "../fixtures/UmaEcosystem.Fixture";
 import { anyValue, BigNumber, expect, ethers, SignerWithAddress } from "../utils";
 import { InsuranceArbitrator } from "../../typechain";
+import { insuredAmount, insuredEvent } from "./constants";
 import { getPolicyIdFromTx } from "./utils";
 
 let insuranceArbitrator: InsuranceArbitrator, usdc: ExpandedERC20Ethers;
 let deployer: SignerWithAddress, insurer: SignerWithAddress, insured: SignerWithAddress;
-let insuredAmount: BigNumber;
-let insuredEvent: string;
 
 describe("Insurance Arbitrator: Issue", function () {
   beforeEach(async function () {
     [deployer, insurer, insured] = await ethers.getSigners();
     await umaEcosystemFixture();
     ({ usdc, insuranceArbitrator } = await insuranceArbitratorFixture());
-
-    insuredAmount = ethers.utils.parseUnits("157000", await usdc.decimals()); // 157000 USDC
-    insuredEvent = "Bad things have happened";
 
     // mint some fresh tokens for the insurer.
     await usdc.connect(deployer).mint(insurer.address, insuredAmount);

--- a/test/InsuranceArbitrator/InsuranceArbitrator.Issue.ts
+++ b/test/InsuranceArbitrator/InsuranceArbitrator.Issue.ts
@@ -1,0 +1,54 @@
+import { ExpandedERC20Ethers } from "@uma/contracts-node";
+import { insuranceArbitratorFixture } from "../fixtures/InsuranceArbitrator.Fixture";
+import { umaEcosystemFixture } from "../fixtures/UmaEcosystem.Fixture";
+import { anyValue, BigNumber, expect, ethers, SignerWithAddress } from "../utils";
+import { InsuranceArbitrator } from "../../typechain";
+import { getPolicyIdFromTx } from "./utils";
+
+let insuranceArbitrator: InsuranceArbitrator, usdc: ExpandedERC20Ethers;
+let deployer: SignerWithAddress, insurer: SignerWithAddress, insured: SignerWithAddress;
+let insuredAmount: BigNumber;
+let insuredEvent: string;
+
+describe("Insurance Arbitrator: Issue", function () {
+  beforeEach(async function () {
+    [deployer, insurer, insured] = await ethers.getSigners();
+    await umaEcosystemFixture();
+    ({ usdc, insuranceArbitrator } = await insuranceArbitratorFixture());
+
+    insuredAmount = ethers.utils.parseUnits("157000", await usdc.decimals()); // 157000 USDC
+    insuredEvent = "Bad things have happened";
+
+    // mint some fresh tokens for the insurer.
+    await usdc.connect(deployer).mint(insurer.address, insuredAmount);
+    // Approve the InsuranceArbitrator to spend tokens.
+    await usdc.connect(insurer).approve(insuranceArbitrator.address, insuredAmount);
+  });
+  it("Issuing insurance correctly pulls tokens and changes contract state", async function () {
+    const insurerBalanceBefore = await usdc.balanceOf(insurer.address);
+    const contractBalanceBefore = await usdc.balanceOf(insuranceArbitrator.address);
+
+    // Issue new insurance policy.
+    const issueInsuranceTx = insuranceArbitrator
+      .connect(insurer)
+      .issueInsurance(insuredEvent, insured.address, usdc.address, insuredAmount);
+
+    // Verify emitted transaction log.
+    await expect(issueInsuranceTx)
+      .to.emit(insuranceArbitrator, "PolicyIssued")
+      .withArgs(anyValue, insurer.address, insuredEvent, insured.address, usdc.address, insuredAmount);
+
+    // Verify insured amount has been deposited.
+    expect(await usdc.balanceOf(insurer.address)).to.equal(insurerBalanceBefore.sub(insuredAmount));
+    expect(await usdc.balanceOf(insuranceArbitrator.address)).to.equal(contractBalanceBefore.add(insuredAmount));
+
+    // Verify contract state has updated.
+    const policyId = await getPolicyIdFromTx(insuranceArbitrator, issueInsuranceTx);
+    const insurancePolicy = await insuranceArbitrator.insurancePolicies(policyId);
+    expect(insurancePolicy.claimInitiated).to.equal(false);
+    expect(insurancePolicy.insuredEvent).to.equal(insuredEvent);
+    expect(insurancePolicy.insuredAddress).to.equal(insured.address);
+    expect(insurancePolicy.currency).to.equal(usdc.address);
+    expect(insurancePolicy.insuredAmount).to.equal(insuredAmount);
+  });
+});

--- a/test/InsuranceArbitrator/InsuranceArbitrator.Settle.ts
+++ b/test/InsuranceArbitrator/InsuranceArbitrator.Settle.ts
@@ -17,7 +17,7 @@ let deployer: SignerWithAddress,
   claimant: SignerWithAddress,
   disputer: SignerWithAddress,
   settler: SignerWithAddress;
-let policyId: string;
+let policyId: string, claimId: string;
 let expectedAncillaryData: string;
 let expectedBond: BigNumber;
 let requestTime: BigNumber, expectedExpirationTime: BigNumber;
@@ -49,7 +49,8 @@ describe("Insurance Arbitrator: Settle", function () {
 
     // Submit claim and grab required request details for interacting with Optimistic Oracle.
     requestTime = await timer.getCurrentTime();
-    await insuranceArbitrator.connect(claimant).submitClaim(policyId);
+    const submitClaimTx = insuranceArbitrator.connect(claimant).submitClaim(policyId);
+    claimId = await getClaimIdFromTx(insuranceArbitrator, submitClaimTx);
     expectedAncillaryData = constructAncillaryData(insuredEvent);
     expectedExpirationTime = await getExpirationTime(insuranceArbitrator, requestTime);
   });
@@ -59,5 +60,33 @@ describe("Insurance Arbitrator: Settle", function () {
         .connect(settler)
         .settle(insuranceArbitrator.address, identifier, requestTime, expectedAncillaryData)
     ).to.be.reverted;
+  });
+  it("Settle after liveness without dispute", async function () {
+    const insuredBalanceBefore = await usdc.balanceOf(insured.address);
+    const contractBalanceBefore = await usdc.balanceOf(insuranceArbitrator.address);
+    const claimantBalanceBefore = await usdc.balanceOf(claimant.address);
+    const ooBalanceBefore = await usdc.balanceOf(optimisticOracle.address);
+
+    // Advance time post liveness and settle through Optimistic Oracle.
+    await optimisticOracle.setCurrentTime(expectedExpirationTime);
+    const settleTx = optimisticOracle
+      .connect(settler)
+      .settle(insuranceArbitrator.address, identifier, requestTime, expectedAncillaryData);
+
+    // Verify emitted transaction log.
+    await expect(settleTx).to.emit(insuranceArbitrator, "ClaimAccepted").withArgs(claimId, policyId);
+
+    // Verify insured amount has been paid and bond returned.
+    expect(await usdc.balanceOf(insured.address)).to.equal(insuredBalanceBefore.add(insuredAmount));
+    expect(await usdc.balanceOf(insuranceArbitrator.address)).to.equal(contractBalanceBefore.sub(insuredAmount));
+    expect(await usdc.balanceOf(claimant.address)).to.equal(claimantBalanceBefore.add(expectedBond));
+    expect(await usdc.balanceOf(optimisticOracle.address)).to.equal(ooBalanceBefore.sub(expectedBond));
+
+    // Repeated claim on paid out insurance should not be possible.
+    await usdc.connect(deployer).mint(claimant.address, expectedBond);
+    await usdc.connect(claimant).approve(insuranceArbitrator.address, expectedBond);
+    await expect(insuranceArbitrator.connect(claimant).submitClaim(policyId)).to.be.revertedWith(
+      "Insurance not issued"
+    );
   });
 });

--- a/test/InsuranceArbitrator/InsuranceArbitrator.Settle.ts
+++ b/test/InsuranceArbitrator/InsuranceArbitrator.Settle.ts
@@ -163,4 +163,9 @@ describe("Insurance Arbitrator: Settle", function () {
     await optimisticOracle.setCurrentTime((await (await ethers.provider.getBlock("latest")).timestamp) + 1);
     await expect(insuranceArbitrator.connect(claimant).submitClaim(policyId)).not.to.be.reverted;
   });
+  it("Cannot spoof the callback", async function () {
+    await expect(
+      insuranceArbitrator.connect(insured).priceSettled(identifier, requestTime, expectedAncillaryData, YES_ANSWER)
+    ).to.be.revertedWith("Unauthorized callback");
+  });
 });

--- a/test/InsuranceArbitrator/InsuranceArbitrator.Settle.ts
+++ b/test/InsuranceArbitrator/InsuranceArbitrator.Settle.ts
@@ -1,0 +1,63 @@
+import { ExpandedERC20Ethers, OptimisticOracleV2Ethers, StoreEthers, TimerEthers } from "@uma/contracts-node";
+import { insuranceArbitratorFixture } from "../fixtures/InsuranceArbitrator.Fixture";
+import { umaEcosystemFixture } from "../fixtures/UmaEcosystem.Fixture";
+import { anyValue, BigNumber, expect, ethers, SignerWithAddress, toWei, randomBytes32 } from "../utils";
+import { InsuranceArbitrator } from "../../typechain";
+import { identifier, insuredAmount, insuredEvent, yesPrice } from "./constants";
+import { constructAncillaryData, getClaimIdFromTx, getExpirationTime, getPolicyIdFromTx } from "./utils";
+
+let insuranceArbitrator: InsuranceArbitrator,
+  usdc: ExpandedERC20Ethers,
+  store: StoreEthers,
+  optimisticOracle: OptimisticOracleV2Ethers,
+  timer: TimerEthers;
+let deployer: SignerWithAddress,
+  insurer: SignerWithAddress,
+  insured: SignerWithAddress,
+  claimant: SignerWithAddress,
+  disputer: SignerWithAddress,
+  settler: SignerWithAddress;
+let policyId: string;
+let expectedAncillaryData: string;
+let expectedBond: BigNumber;
+let requestTime: BigNumber, expectedExpirationTime: BigNumber;
+
+describe("Insurance Arbitrator: Settle", function () {
+  beforeEach(async function () {
+    [deployer, insurer, insured, claimant, disputer, settler] = await ethers.getSigners();
+    ({ store, optimisticOracle, timer } = await umaEcosystemFixture());
+    ({ usdc, insuranceArbitrator } = await insuranceArbitratorFixture());
+
+    // Mint and approve insuredAmount tokens for the insurer.
+    await usdc.connect(deployer).mint(insurer.address, insuredAmount);
+    await usdc.connect(insurer).approve(insuranceArbitrator.address, insuredAmount);
+
+    // Issue insurance policy and grab emitted policyId.
+    const issueInsuranceTx = insuranceArbitrator
+      .connect(insurer)
+      .issueInsurance(insuredEvent, insured.address, insuredAmount);
+    policyId = await getPolicyIdFromTx(insuranceArbitrator, issueInsuranceTx);
+
+    // Mint and approve expected proposal bond for the claimant and disputer.
+    const finalFee = (await store.computeFinalFee(usdc.address)).rawValue;
+    const oracleBondPercentage = await insuranceArbitrator.oracleBondPercentage();
+    expectedBond = oracleBondPercentage.mul(insuredAmount).div(toWei("1")).add(finalFee);
+    await usdc.connect(deployer).mint(claimant.address, expectedBond);
+    await usdc.connect(claimant).approve(insuranceArbitrator.address, expectedBond);
+    await usdc.connect(deployer).mint(disputer.address, expectedBond);
+    await usdc.connect(disputer).approve(optimisticOracle.address, expectedBond);
+
+    // Submit claim and grab required request details for interacting with Optimistic Oracle.
+    requestTime = await timer.getCurrentTime();
+    await insuranceArbitrator.connect(claimant).submitClaim(policyId);
+    expectedAncillaryData = constructAncillaryData(insuredEvent);
+    expectedExpirationTime = await getExpirationTime(insuranceArbitrator, requestTime);
+  });
+  it("Cannot settle early", async function () {
+    await expect(
+      optimisticOracle
+        .connect(settler)
+        .settle(insuranceArbitrator.address, identifier, requestTime, expectedAncillaryData)
+    ).to.be.reverted;
+  });
+});

--- a/test/InsuranceArbitrator/constants.ts
+++ b/test/InsuranceArbitrator/constants.ts
@@ -6,7 +6,7 @@ export const insuredEvent = "Bad things have happened";
 
 export const identifier = utf8ToHex("YES_OR_NO_QUERY");
 
-export const yesPrice = toWei("1");
+export const YES_ANSWER = toWei("1");
 
 export const ancillaryDataHead = 'q:"Had the following insured event occurred as of request timestamp: ';
 

--- a/test/InsuranceArbitrator/constants.ts
+++ b/test/InsuranceArbitrator/constants.ts
@@ -8,6 +8,8 @@ export const identifier = utf8ToHex("YES_OR_NO_QUERY");
 
 export const YES_ANSWER = toWei("1");
 
+export const NO_ANSWER = toWei("0");
+
 export const ancillaryDataHead = 'q:"Had the following insured event occurred as of request timestamp: ';
 
 export const ancillaryDataTail = '?"';

--- a/test/InsuranceArbitrator/constants.ts
+++ b/test/InsuranceArbitrator/constants.ts
@@ -1,5 +1,13 @@
-import { BigNumber, parseUnits } from "../utils";
+import { BigNumber, parseUnits, toWei, utf8ToHex } from "../utils";
 
 export const insuredAmount: BigNumber = parseUnits("157000", 6); // 157000 USDC
 
 export const insuredEvent = "Bad things have happened";
+
+export const identifier = utf8ToHex("YES_OR_NO_QUERY");
+
+export const yesPrice = toWei("1");
+
+export const ancillaryDataHead = 'q:"Had the following insured event occurred as of request timestamp: ';
+
+export const ancillaryDataTail = '?"';

--- a/test/InsuranceArbitrator/constants.ts
+++ b/test/InsuranceArbitrator/constants.ts
@@ -1,0 +1,5 @@
+import { BigNumber, parseUnits } from "../utils";
+
+export const insuredAmount: BigNumber = parseUnits("157000", 6); // 157000 USDC
+
+export const insuredEvent = "Bad things have happened";

--- a/test/InsuranceArbitrator/utils.ts
+++ b/test/InsuranceArbitrator/utils.ts
@@ -1,0 +1,11 @@
+import { ContractTransaction, EventFilter } from "ethers";
+import { InsuranceArbitrator } from "../../typechain";
+
+export async function getPolicyIdFromTx(
+  insuranceArbitrator: InsuranceArbitrator,
+  tx: Promise<ContractTransaction>
+): Promise<string> {
+  const blockNumber = (await (await tx).wait()).blockNumber;
+  const [matchedEvent] = await insuranceArbitrator.queryFilter(<EventFilter>"PolicyIssued", blockNumber, blockNumber);
+  return matchedEvent.args.policyId;
+}

--- a/test/InsuranceArbitrator/utils.ts
+++ b/test/InsuranceArbitrator/utils.ts
@@ -1,5 +1,7 @@
-import { ContractTransaction, EventFilter } from "ethers";
+import { BigNumber, ContractTransaction, EventFilter } from "ethers";
 import { InsuranceArbitrator } from "../../typechain";
+import { utf8ToHexString } from "../utils";
+import { ancillaryDataHead, ancillaryDataTail } from "./constants";
 
 export async function getPolicyIdFromTx(
   insuranceArbitrator: InsuranceArbitrator,
@@ -8,4 +10,24 @@ export async function getPolicyIdFromTx(
   const blockNumber = (await (await tx).wait()).blockNumber;
   const [matchedEvent] = await insuranceArbitrator.queryFilter(<EventFilter>"PolicyIssued", blockNumber, blockNumber);
   return matchedEvent.args.policyId;
+}
+
+export async function getClaimIdFromTx(
+  insuranceArbitrator: InsuranceArbitrator,
+  tx: Promise<ContractTransaction>
+): Promise<string> {
+  const blockNumber = (await (await tx).wait()).blockNumber;
+  const [matchedEvent] = await insuranceArbitrator.queryFilter(<EventFilter>"ClaimSubmitted", blockNumber, blockNumber);
+  return matchedEvent.args.claimId;
+}
+
+export function constructAncillaryData(insuredEvent: string): string {
+  return utf8ToHexString(ancillaryDataHead + insuredEvent + ancillaryDataTail);
+}
+
+export async function getExpirationTime(
+  insuranceArbitrator: InsuranceArbitrator,
+  claimTimestamp: BigNumber
+): Promise<BigNumber> {
+  return (await insuranceArbitrator.optimisticOracleLivenessTime()).add(claimTimestamp);
 }

--- a/test/fixtures/InsuranceArbitrator.Fixture.ts
+++ b/test/fixtures/InsuranceArbitrator.Fixture.ts
@@ -32,7 +32,7 @@ export async function deployInsuranceArbitrator(ethers: typeof hre.ethers) {
   // Deploy the InsuranceArbitrator contract.
   const insuranceArbitrator = (await (
     await getContractFactory("InsuranceArbitrator", deployer)
-  ).deploy(parentFixture.finder.address, parentFixture.timer.address)) as InsuranceArbitrator;
+  ).deploy(parentFixture.finder.address, usdc.address, parentFixture.timer.address)) as InsuranceArbitrator;
 
   return { usdc, insuranceArbitrator };
 }

--- a/test/fixtures/InsuranceArbitrator.Fixture.ts
+++ b/test/fixtures/InsuranceArbitrator.Fixture.ts
@@ -1,0 +1,38 @@
+import { ExpandedERC20Ethers } from "@uma/contracts-node";
+import hre from "hardhat";
+import { getContractFactory } from "../utils";
+import { TokenRolesEnum } from "../constants";
+import { umaEcosystemFixture } from "./UmaEcosystem.Fixture";
+import { InsuranceArbitrator } from "../../typechain";
+
+export const insuranceArbitratorFixture = hre.deployments.createFixture(async ({ ethers }) => {
+  return await deployInsuranceArbitrator(ethers);
+});
+
+export async function deployInsuranceArbitrator(ethers: typeof hre.ethers) {
+  const [deployer] = await ethers.getSigners();
+
+  // This fixture is dependent on the UMA ecosystem fixture. Run it first and grab the output. This is used in the
+  // deployments that follows.
+  const parentFixture = await umaEcosystemFixture();
+
+  // deploys currency for InsuranceArbitrator contract
+  const usdc = (await (
+    await getContractFactory("ExpandedERC20", deployer)
+  ).deploy("USD Coin", "USDC", 6)) as ExpandedERC20Ethers;
+  await usdc.addMember(TokenRolesEnum.MINTER, deployer.address);
+
+  // Sets collateral as approved in the UMA collateralWhitelist.
+  await parentFixture.collateralWhitelist.addToWhitelist(usdc.address);
+
+  // Sets finalFee to 1500 USDC.
+  const finalFee = ethers.utils.parseUnits("1500", await usdc.decimals());
+  await parentFixture.store.setFinalFee(usdc.address, { rawValue: finalFee });
+
+  // Deploy the InsuranceArbitrator contract.
+  const insuranceArbitrator = (await (
+    await getContractFactory("InsuranceArbitrator", deployer)
+  ).deploy(parentFixture.finder.address, parentFixture.timer.address)) as InsuranceArbitrator;
+
+  return { usdc, insuranceArbitrator };
+}

--- a/test/fixtures/UmaEcosystem.Fixture.ts
+++ b/test/fixtures/UmaEcosystem.Fixture.ts
@@ -1,17 +1,19 @@
 import { getContractFactory, utf8ToHex, hre } from "../utils";
 import { proposalLiveness, zeroRawValue, identifier } from "../constants";
 import { interfaceName } from "@uma/common";
-import { OptimisticOracleV2Ethers, MockOracleAncillaryEthers } from "@uma/contracts-node";
+import { OptimisticOracleV2Ethers, MockOracleAncillaryEthers, StoreEthers, TimerEthers } from "@uma/contracts-node";
 
 export const umaEcosystemFixture = hre.deployments.createFixture(async ({ ethers }) => {
   const [deployer] = await ethers.getSigners();
 
   // Deploy the UMA ecosystem contracts.
-  const timer = await (await getContractFactory("Timer", deployer)).deploy();
+  const timer = (await (await getContractFactory("Timer", deployer)).deploy()) as TimerEthers;
   const finder = await (await getContractFactory("Finder", deployer)).deploy();
   const collateralWhitelist = await (await getContractFactory("AddressWhitelist", deployer)).deploy();
   const identifierWhitelist = await (await getContractFactory("IdentifierWhitelist", deployer)).deploy();
-  const store = await (await getContractFactory("Store", deployer)).deploy(zeroRawValue, zeroRawValue, timer.address);
+  const store = (await (
+    await getContractFactory("Store", deployer)
+  ).deploy(zeroRawValue, zeroRawValue, timer.address)) as StoreEthers;
   const mockOracle = (await (
     await getContractFactory("MockOracleAncillary", deployer)
   ).deploy(finder.address, timer.address)) as MockOracleAncillaryEthers;

--- a/test/fixtures/index.ts
+++ b/test/fixtures/index.ts
@@ -1,3 +1,4 @@
 export * from "./EventBasedPredictionMarket.Fixture";
+export * from "./InsuranceArbitrator.Fixture";
 export * from "./OptimisticDepositBox.Fixture";
 export * from "./UmaEcosystem.Fixture";

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -71,6 +71,9 @@ export function getAllFilesInPath(dirPath: string, arrayOfFiles: string[] = []):
 
 export const toWei = (num: string | number | BigNumber) => ethers.utils.parseEther(num.toString());
 
+export const parseUnits = (num: string | number | BigNumber, dec: string | number | BigNumber) =>
+  ethers.utils.parseUnits(num.toString(), dec.toString());
+
 export const utf8ToHex = (input: string) => ethers.utils.formatBytes32String(input);
 
 export { anyValue, expect, Contract, ethers, hre, BigNumber, Signer };

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -78,4 +78,6 @@ export const utf8ToHex = (input: string) => ethers.utils.formatBytes32String(inp
 
 export const utf8ToHexString = (input: string) => ethers.utils.hexlify(ethers.utils.toUtf8Bytes(input));
 
+export const randomBytes32 = () => ethers.utils.hexlify(ethers.utils.randomBytes(32));
+
 export { anyValue, expect, Contract, ethers, hre, BigNumber, Signer };

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -6,6 +6,7 @@ import hre from "hardhat";
 import { ethers } from "hardhat";
 import { BigNumber, Signer, Contract, ContractFactory } from "ethers";
 import { FactoryOptions } from "hardhat/types";
+import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
 
 export interface SignerWithAddress extends Signer {
   address: string;
@@ -72,4 +73,4 @@ export const toWei = (num: string | number | BigNumber) => ethers.utils.parseEth
 
 export const utf8ToHex = (input: string) => ethers.utils.formatBytes32String(input);
 
-export { expect, Contract, ethers, hre, BigNumber, Signer };
+export { anyValue, expect, Contract, ethers, hre, BigNumber, Signer };

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -76,4 +76,6 @@ export const parseUnits = (num: string | number | BigNumber, dec: string | numbe
 
 export const utf8ToHex = (input: string) => ethers.utils.formatBytes32String(input);
 
+export const utf8ToHexString = (input: string) => ethers.utils.hexlify(ethers.utils.toUtf8Bytes(input));
+
 export { anyValue, expect, Contract, ethers, hre, BigNumber, Signer };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2371,6 +2371,18 @@
     mcl-wasm "^0.7.1"
     rustbn.js "~0.2.0"
 
+"@nomicfoundation/hardhat-chai-matchers@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-1.0.4.tgz#4b5c0d6eba637aabb49342272ae15ee6877a462e"
+  integrity sha512-n/5UMwGaUK2zM8ALuMChVwB1lEPeDTb5oBjQ1g7hVsUdS8x+XG9JIEp4Ze6Bwy98tghA7Y1+PCH4SNE2P3UQ2g==
+  dependencies:
+    "@ethersproject/abi" "^5.1.2"
+    "@types/chai-as-promised" "^7.1.3"
+    chai-as-promised "^7.1.1"
+    chalk "^2.4.2"
+    deep-eql "^4.0.1"
+    ordinal "^1.0.3"
+
 "@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@nomicfoundation/solidity-analyzer-darwin-arm64/-/solidity-analyzer-darwin-arm64-0.1.0.tgz#83a7367342bd053a76d04bbcf4f373fef07cf760"
@@ -3111,6 +3123,13 @@
   integrity sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==
   dependencies:
     "@types/node" "*"
+
+"@types/chai-as-promised@^7.1.3":
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz#6e016811f6c7a64f2eed823191c3a6955094e255"
+  integrity sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==
+  dependencies:
+    "@types/chai" "*"
 
 "@types/chai@*", "@types/chai@^4.2.0", "@types/chai@^4.2.21":
   version "4.3.0"
@@ -5194,6 +5213,13 @@ cbor@^5.0.2, cbor@^5.1.0:
     bignumber.js "^9.0.1"
     nofilter "^1.0.4"
 
+chai-as-promised@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
+  integrity sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==
+  dependencies:
+    check-error "^1.0.2"
+
 chai@^4.2.0, chai@^4.3.4:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.6.tgz#ffe4ba2d9fa9d6680cc0b370adae709ec9011e9c"
@@ -5960,6 +5986,13 @@ deep-eql@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
   integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
+  dependencies:
+    type-detect "^4.0.0"
+
+deep-eql@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-4.1.1.tgz#b1154ea8c95012d9f23f37f4eecfd2ee8e5b9323"
+  integrity sha512-rc6HkZswtl+KMi/IODZ8k7C/P37clC2Rf1HYI11GqdbgvggIyHjsU5MdjlTlaP6eu24c0sR3mcW2SqsVZ1sXUw==
   dependencies:
     type-detect "^4.0.0"
 
@@ -11343,6 +11376,11 @@ optionator@^0.9.1:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.3"
+
+ordinal@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ordinal/-/ordinal-1.0.3.tgz#1a3c7726a61728112f50944ad7c35c06ae3a0d4d"
+  integrity sha512-cMddMgb2QElm8G7vdaa02jhUNbTSrhsgAGUz1OokD83uJTwSUn+nKoNoKVVaRa08yF6sgfO7Maou1+bgLd9rdQ==
 
 os-homedir@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
Adds tests for following functionality of Insurance Arbitrator:
- Issuing insurance policy
- Initiating insurance claims
- Settling insurance claims

In order to have timing being in sync with Optimistic Oracle test instance I had to inherit Testable contract in Insurance Arbitrator and use its `getCurrentTime()` method instead of accessing `block.timestamp` directly.