### PR TITLE
fix: price disputed require

### DIFF
--- a/contracts/EventBasedPredictionMarket.sol
+++ b/contracts/EventBasedPredictionMarket.sol
@@ -167,12 +167,12 @@ contract EventBasedPredictionMarket is Testable {
         OptimisticOracleV2Interface optimisticOracle = getOptimisticOracle();
         require(msg.sender == address(optimisticOracle), "not authorized");
 
-        requestTimestamp = getCurrentTime();
-        require(timestamp <= requestTimestamp, "different timestamps");
+        require(timestamp == requestTimestamp, "different timestamps");
         require(identifier == priceIdentifier, "same identifier");
         require(keccak256(ancillaryData) == keccak256(customAncillaryData), "same ancillary data");
         require(refund == proposerReward, "same proposerReward amount");
 
+        requestTimestamp = getCurrentTime();
         _requestOraclePrice();
     }
 


### PR DESCRIPTION
Changes proposed in this PR:
- EventBasedPredictionMarket: more consistent requires in `priceDisputed` 